### PR TITLE
Feature #1: Search

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "react": "^15.4.2",
     "react-bootstrap": "^0.30.7",
     "react-bootstrap-modal": "^3.0.1",
+    "react-bootstrap-typeahead": "^1.1.0",
     "react-dom": "^15.4.2",
     "react-leaflet": "^1.1.0",
     "react-router": "^3.0.2",

--- a/src/components/main.js
+++ b/src/components/main.js
@@ -144,12 +144,11 @@ export default class Main extends React.Component {
   }
 
   onSearchResultsUpdate(searchResults) {
-    if (searchResults.length) {
-      const { lat, lon } = searchResults[0];
-      this.setState({ searchResults, lat, lon, zoom: 14, highlightedSearchSuggestion: null, lengthMeasurePoints: [], tool: null });
-    } else {
-      this.setState({ searchResults, highlightedSearchSuggestion: null, lengthMeasurePoints: [], tool: null });
-    }
+    this.setState({ searchResults, highlightedSearchSuggestion: null, lengthMeasurePoints: [], tool: null });
+  }
+
+  refocusMap(lat, lon, zoom) {
+    this.setState({lat, lon, zoom});
   }
 
   setRoutePlannerPointPickMode(routePlannerPickMode) {
@@ -230,7 +229,9 @@ export default class Main extends React.Component {
 
             <SearchResults 
               highlightedSearchSuggestion={highlightedSearchSuggestion} 
-              searchResults={searchResults}/>
+              searchResults={searchResults}
+              doMapRefocus={b(this.refocusMap)}
+              map={this.refs.map}/>
 
             <Measurement lengthMeasurePoints={lengthMeasurePoints} onMeasureMarkerDrag={b(this.handleMeasureMarkerDrag)}/>
 

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -40,6 +40,10 @@ export default class Search extends React.Component {
     this.props.onSearchResultsUpdate(selectedResults);
   }
 
+  onSuggestionHighlightChange(result) {
+    this.props.onSearchSuggestionHighlightChange(result);
+  }
+
   render() {
     const b = (fn, ...args) => fn.bind(this, ...args);
     return (
@@ -58,7 +62,9 @@ export default class Search extends React.Component {
             onChange={b(this.onSelectionChange)}
             emptyLabel={'Nenašli sme žiadne výsledky'}
             renderMenuItemChildren={(result) => (
-              <div key={result.label + result.id}>
+              <div key={result.label + result.id} 
+              onMouseEnter={b(this.onSuggestionHighlightChange, result)}
+              onMouseLeave={b(this.onSuggestionHighlightChange, null)}>
                 <span>{result.tags.name} </span><br/>
                 <span>({result.tags.type})</span>
               </div>
@@ -73,5 +79,6 @@ Search.propTypes = {
   lat: React.PropTypes.string,
   lon: React.PropTypes.string,
   zoom: React.PropTypes.number,
+  onSearchSuggestionHighlightChange: React.PropTypes.func.isRequired,
   onSearchResultsUpdate: React.PropTypes.func.isRequired
 };

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -37,7 +37,7 @@ export default class Search extends React.Component {
   }
 
   onSelectionChange(selectedResults) {
-    this.props.onSearchResultsUpdate(selectedResults);
+    this.props.onSelectSearchResult(selectedResults[0]);
   }
 
   onSuggestionHighlightChange(result) {
@@ -80,5 +80,5 @@ Search.propTypes = {
   lon: React.PropTypes.string,
   zoom: React.PropTypes.number,
   onSearchSuggestionHighlightChange: React.PropTypes.func.isRequired,
-  onSearchResultsUpdate: React.PropTypes.func.isRequired
+  onSelectSearchResult: React.PropTypes.func.isRequired
 };

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -7,7 +7,7 @@ export default class Search extends React.Component {
     super(props);
 
     this.state = {
-      searchResults: [],
+      searchSuggestions: [],
       searchQuery: '',
       lat: this.props.lat, 
       lon: this.props.lon,
@@ -27,21 +27,17 @@ export default class Search extends React.Component {
         + `?format=jsonv2&lat=${lat}&lon=${lon}&zoom=${zoom}&namedetails=1&extratags=1`, {
       method: 'GET'
     }).then(res => res.json()).then(data => {
-      const searchResults = data.map((d, id) => {
+      const searchSuggestions = data.map((d, id) => {
         const name = d.namedetails.name;
         const tags = { name, type: d.type };
         return { id, label: name, lat: d.lat, lon: d.lon, tags  };
       });
-      this.setState({searchResults});  
+      this.setState({searchSuggestions});  
     });
   }
 
-  clearSearch() {
-    this.setState({ searchQuery: null, searchResults: []  });
-  } 
-
-  searchResultSelected(result) {
-    console.log(result);
+  onSelectionChange(selectedResults) {
+    this.props.onSearchResultsUpdate(selectedResults);
   }
 
   render() {
@@ -55,13 +51,14 @@ export default class Search extends React.Component {
             delay={500}
             ignoreDiacritics={true}
             onSearch={b(this.doSearch)}
-            options={this.state.searchResults}
+            options={this.state.searchSuggestions}
             searchText="Hľadám ..."
             placeholder="Brusno"
             clearButton={true}
-            emptyLabel={'Nenašli sme žiadne výsledky' + this.state.searchResults.length}
+            onChange={b(this.onSelectionChange)}
+            emptyLabel={'Nenašli sme žiadne výsledky'}
             renderMenuItemChildren={(result) => (
-              <div key={result.label + result.id} onClick={b(this.searchResultSelected, result)}>
+              <div key={result.label + result.id}>
                 <span>{result.tags.name} </span><br/>
                 <span>({result.tags.type})</span>
               </div>

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -24,7 +24,7 @@ export default class Search extends React.Component {
     const { lat, lon, zoom } = this.state;
     // fetch(`https://www.freemap.sk/api/0.1/q/${encodeURIComponent(searchQuery)}&lat=${lat}&lon=${lon}&zoom=${zoom}`, {
     fetch(`https://nominatim.openstreetmap.org/search/${encodeURIComponent(searchQuery)}`
-        + `?format=jsonv2&lat=${lat}&lon=${lon}&zoom=${zoom}&namedetails=1&extratags=1`, {
+        + `?format=jsonv2&lat=${lat}&lon=${lon}&zoom=${zoom}&namedetails=1&extratags=1&countrycodes=SK`, {
       method: 'GET'
     }).then(res => res.json()).then(data => {
       const searchSuggestions = data.map((d, id) => {

--- a/src/components/searchResults.js
+++ b/src/components/searchResults.js
@@ -12,9 +12,9 @@ export default class SearchResults extends React.Component {
   }
 
   refocusMapIfNeeded(newProps) {
-    const mapBound = this.props.map.getBounds();
-    const mapZoom = this.props.map.getZoom();
     if (newProps.highlightedSearchSuggestion) {
+      const mapBound = this.props.map.getBounds();
+      const mapZoom = this.props.map.getZoom();
       const h = newProps.highlightedSearchSuggestion;
       const hLatLon = L.latLng(h.lat, h.lon);
       if (mapZoom < 13 || !mapBound.contains(hLatLon)) {

--- a/src/components/searchResults.js
+++ b/src/components/searchResults.js
@@ -40,7 +40,7 @@ export default class SearchResults extends React.Component {
 
           return (
             <Marker key={id} position={L.latLng(lat, lon)}>
-              <Tooltip><span dangerouslySetInnerHTML={{ __html }}/></Tooltip>
+              <Tooltip opacity={1.0}><span dangerouslySetInnerHTML={{ __html }}/></Tooltip>
             </Marker>
           );
         })}

--- a/src/components/searchResults.js
+++ b/src/components/searchResults.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { toHtml } from '../poiTypes';
-import { Marker, Popup } from 'react-leaflet';
+import { Marker, Tooltip } from 'react-leaflet';
 
 export default class SearchResults extends React.Component {
   componentWillReceiveProps(newProps) {
@@ -40,7 +40,7 @@ export default class SearchResults extends React.Component {
 
           return (
             <Marker key={id} position={L.latLng(lat, lon)}>
-              {__html && <Popup autoPan={false}><span dangerouslySetInnerHTML={{ __html }}/></Popup>}
+              <Tooltip><span dangerouslySetInnerHTML={{ __html }}/></Tooltip>
             </Marker>
           );
         })}

--- a/src/components/searchResults.js
+++ b/src/components/searchResults.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { toHtml } from '../poiTypes';
+import { Marker, Popup } from 'react-leaflet';
+
+export default class SearchResults extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      highlightedSearchSuggestion: this.props.highlightedSearchSuggestion,
+      searchResults: this.props.searchResults, 
+    };
+  }
+
+componentWillReceiveProps(newProps) {
+  this.setState(newProps);
+}
+
+  render() {
+    const {searchResults, highlightedSearchSuggestion} = this.state;
+    const suggestionIcon = new L.Icon({
+      iconSize: [ 23, 37 ],
+      iconUrl: require('../images/marker-icon-grey.png'),
+      iconRetinaUrl: require('../images/marker-icon-2x-grey.png')
+    });
+    return (
+      <div>
+        {searchResults.map(({ id, lat, lon, tags }) => {
+          const __html = toHtml(tags);
+
+          return (
+            <Marker key={id} position={L.latLng(lat, lon)}>
+              {__html && <Popup autoPan={false}><span dangerouslySetInnerHTML={{ __html }}/></Popup>}
+            </Marker>
+          );
+        })}
+
+        {highlightedSearchSuggestion &&
+          <Marker 
+            key={highlightedSearchSuggestion.id} 
+            position={L.latLng(highlightedSearchSuggestion.lat, highlightedSearchSuggestion.lon)}
+            icon={suggestionIcon}>
+          </Marker>
+          }
+      </div>
+    );
+  }
+}
+
+SearchResults.propTypes = {
+  highlightedSearchSuggestion: React.PropTypes.any,
+  searchResults: React.PropTypes.array
+};

--- a/src/components/searchResults.js
+++ b/src/components/searchResults.js
@@ -3,6 +3,29 @@ import { toHtml } from '../poiTypes';
 import { Marker, Popup } from 'react-leaflet';
 
 export default class SearchResults extends React.Component {
+  componentWillReceiveProps(newProps) {
+    const highlightChanged = JSON.stringify(newProps.highlightedSearchSuggestion) != JSON.stringify(this.props.highlightedSearchSuggestion);
+    const resultsChanged = JSON.stringify(newProps.searchResults) != JSON.stringify(this.props.searchResults);
+    if (highlightChanged || resultsChanged) {
+      this.refocusMapIfNeeded(newProps);
+    }
+  }
+
+  refocusMapIfNeeded(newProps) {
+    const mapBound = this.props.map.getBounds();
+    const mapZoom = this.props.map.getZoom();
+    if (newProps.highlightedSearchSuggestion) {
+      const h = newProps.highlightedSearchSuggestion;
+      const hLatLon = L.latLng(h.lat, h.lon);
+      if (mapZoom < 13 || !mapBound.contains(hLatLon)) {
+        this.props.doMapRefocus(h.lat, h.lon, 13);
+      }
+    } else if (newProps.searchResults.length) {
+      const p = newProps.searchResults[0];
+      this.props.doMapRefocus(p.lat, p.lon, 13);
+    }
+  }
+
   render() {
     const {searchResults, highlightedSearchSuggestion} = this.props;
     const suggestionIcon = new L.Icon({
@@ -36,5 +59,7 @@ export default class SearchResults extends React.Component {
 
 SearchResults.propTypes = {
   highlightedSearchSuggestion: React.PropTypes.any,
-  searchResults: React.PropTypes.array
+  searchResults: React.PropTypes.array,
+  doMapRefocus: React.PropTypes.func.isRequired,
+  map: React.PropTypes.any
 };

--- a/src/components/searchResults.js
+++ b/src/components/searchResults.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import { toHtml } from '../poiTypes';
 import { Marker, Tooltip } from 'react-leaflet';
 
 export default class SearchResults extends React.Component {
   componentWillReceiveProps(newProps) {
     const highlightChanged = JSON.stringify(newProps.highlightedSearchSuggestion) != JSON.stringify(this.props.highlightedSearchSuggestion);
-    const resultsChanged = JSON.stringify(newProps.searchResults) != JSON.stringify(this.props.searchResults);
+    const resultsChanged = JSON.stringify(newProps.selectedSearchResult) != JSON.stringify(this.props.selectedSearchResult);
     if (highlightChanged || resultsChanged) {
       this.refocusMapIfNeeded(newProps);
     }
@@ -20,46 +19,49 @@ export default class SearchResults extends React.Component {
       if (mapZoom < 13 || !mapBound.contains(hLatLon)) {
         this.props.doMapRefocus(h.lat, h.lon, 13);
       }
-    } else if (newProps.searchResults.length) {
-      const p = newProps.searchResults[0];
-      this.props.doMapRefocus(p.lat, p.lon, 13);
+    } else if (newProps.selectedSearchResult) {
+      const s = newProps.selectedSearchResult;
+      this.props.doMapRefocus(s.lat, s.lon, 13);
     }
   }
 
   render() {
-    const {searchResults, highlightedSearchSuggestion} = this.props;
     const suggestionIcon = new L.Icon({
       iconSize: [ 23, 37 ],
       iconUrl: require('../images/marker-icon-grey.png'),
       iconRetinaUrl: require('../images/marker-icon-2x-grey.png')
     });
+    const s = this.props.selectedSearchResult;
+    const h = this.props.highlightedSearchSuggestion;
+    let tooltipContent = '';
+    if (s) {
+      tooltipContent = `${s.tags.name} (${s.tags.type})` ;
+    }
     return (
       <div>
-        {searchResults.map(({ id, lat, lon, tags }) => {
-          const __html = toHtml(tags);
+        {s && 
+          <Marker position={L.latLng(s.lat, s.lon)}>
+            <Tooltip opacity={1.0}>
+              <span dangerouslySetInnerHTML={{__html: tooltipContent}}/>
+            </Tooltip>
+          </Marker>
+        }
 
-          return (
-            <Marker key={id} position={L.latLng(lat, lon)}>
-              <Tooltip opacity={1.0}><span dangerouslySetInnerHTML={{ __html }}/></Tooltip>
-            </Marker>
-          );
-        })}
-
-        {highlightedSearchSuggestion &&
+        {h &&
           <Marker 
-            key={highlightedSearchSuggestion.id} 
-            position={L.latLng(highlightedSearchSuggestion.lat, highlightedSearchSuggestion.lon)}
+            key={h.id}
+            position={L.latLng(h.lat, h.lon)}
             icon={suggestionIcon}>
           </Marker>
           }
       </div>
-    );
+  );
   }
 }
 
 SearchResults.propTypes = {
   highlightedSearchSuggestion: React.PropTypes.any,
-  searchResults: React.PropTypes.array,
+  selectedSearchResult: React.PropTypes.any,
   doMapRefocus: React.PropTypes.func.isRequired,
   map: React.PropTypes.any
 };

--- a/src/components/searchResults.js
+++ b/src/components/searchResults.js
@@ -3,21 +3,8 @@ import { toHtml } from '../poiTypes';
 import { Marker, Popup } from 'react-leaflet';
 
 export default class SearchResults extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      highlightedSearchSuggestion: this.props.highlightedSearchSuggestion,
-      searchResults: this.props.searchResults, 
-    };
-  }
-
-componentWillReceiveProps(newProps) {
-  this.setState(newProps);
-}
-
   render() {
-    const {searchResults, highlightedSearchSuggestion} = this.state;
+    const {searchResults, highlightedSearchSuggestion} = this.props;
     const suggestionIcon = new L.Icon({
       iconSize: [ 23, 37 ],
       iconUrl: require('../images/marker-icon-grey.png'),

--- a/src/styles/page.scss
+++ b/src/styles/page.scss
@@ -26,3 +26,13 @@
 .nav-tabs {
   margin-bottom: 0;
 }
+
+.bootstrap-typeahead {
+  padding-right: 15px !important;
+}
+
+.bootstrap-typeahead button.close.bootstrap-typeahead-clear-button {
+  position: absolute;
+  top: 5px;
+  right: -4px;
+}

--- a/src/styles/page.scss
+++ b/src/styles/page.scss
@@ -36,3 +36,7 @@
   top: 5px;
   right: -4px;
 }
+
+.bootstrap-typeahead .bootstrap-typeahead-menu {
+  opacity: 0.9;
+}


### PR DESCRIPTION
vie to nasledovne:
* zobrazi search suggestions a pri mouse over nad suggestion zobrazi polohu na mape a snazi sa to hybat mapou trochu inteligentne
* pri kliknuti na zvoleny search suggestion sa zobrazi uz len jeden vysledny marker -- tu je predstava, ze v hornom menu sa neskor zobrazia moznosti ako navigovat sem/navigovat odtialto/zdielat bod.
* oddelil som poi search markers od bezneho search-u

nedostatky:
* nominatim search nevie pouzivat wildcards, cize search suggestions vlastne nie su suggestions, ale results (pre "Sene" ti to nenajde "Senec") -- bud casom zmenim api call na freemap suggestions, alebo pockame kym nam vyrobia nove freemap backend api /z tohto dovodu aj neriesim, ze typ vysledku je v anglictine tak ako ho dodal nominativ/

kym zacnem robit integraciu zvoleneho search vysledku s planovacom, mali by sme vymysliet ako elegantne resetovat stav ked sa prepiname medzi nastrojmi, lebo uz to zacina byt zmatocne. jedna moznost by bola, ze kazdy nastroj by niekde definoval, ako sa maju zresetovat jeto stavove atributy v main-e ked sa meni nastroj na iny /napr. -- planovac zresetuje body trasy, ale ak pouzivatel zvolil typ transportu bicykel, ten si chce ponechat nastaveny/. 

potom by sa `setTool` metoda mohla premenovat `changeTool` a  robila by nasledovne:

```
pre  kazdy nastroj zresetuj jeho stavove atributy
state.setTool(tool: zvoleny tool)
```