### PR TITLE
Feature #27 add search content actions

### DIFF
--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -120,6 +120,10 @@ class Main extends React.Component {
     }
   }
 
+  showDefaltMainMenuActions() {
+    return this.props.tool !== 'route-planner' && this.props.tool !== 'search';
+  }
+
   render() {
     const { tool, onResetMap, onSetTool, objectsModalShown } = this.props;
     const b = (fn, ...args) => fn.bind(this, ...args);
@@ -140,24 +144,24 @@ class Main extends React.Component {
             </Navbar.Header>
 
             <Navbar.Collapse>
-              {tool !== 'route-planner' &&
-                <div>
-                  <Search/>
-                  <Nav>
-                    <NavItem onClick={b(this.handlePoiSearch)}>
-                      <i className={`fa fa-star`} aria-hidden="true"/> Hľadať POIs
-                    </NavItem>
-                    <NavItem onClick={b(onSetTool, 'measure')} active={tool === 'measure'}>
-                      <i className={`fa fa-arrows-h`} aria-hidden="true"/> Meranie vzdialenosti
-                    </NavItem>
-                    <NavItem onClick={b(onSetTool, 'route-planner')} active={tool === 'route-planner'}>
-                      <i className={`fa fa-map-signs`} aria-hidden="true"/> Plánovač trasy
-                    </NavItem>
-                    <NavItem onClick={b(onSetTool, 'measure-ele')} active={tool === 'measure-ele'}>
-                      <i className={`fa fa-area-chart`} aria-hidden="true"/> Výškomer
-                    </NavItem>
-                  </Nav>
-                </div>
+              {( this.showDefaltMainMenuActions() || tool === 'search' ) &&
+                <Search/>
+              }
+              {this.showDefaltMainMenuActions() &&
+                <Nav>
+                  <NavItem onClick={b(this.handlePoiSearch)}>
+                    <i className={`fa fa-star`} aria-hidden="true"/> Hľadať POIs
+                  </NavItem>
+                  <NavItem onClick={b(onSetTool, 'measure')} active={tool === 'measure'}>
+                    <i className={`fa fa-arrows-h`} aria-hidden="true"/> Meranie vzdialenosti
+                  </NavItem>
+                  <NavItem onClick={b(onSetTool, 'route-planner')} active={tool === 'route-planner'}>
+                    <i className={`fa fa-map-signs`} aria-hidden="true"/> Plánovač trasy
+                  </NavItem>
+                  <NavItem onClick={b(onSetTool, 'measure-ele')} active={tool === 'measure-ele'}>
+                    <i className={`fa fa-area-chart`} aria-hidden="true"/> Výškomer
+                  </NavItem>
+                </Nav>
               }
               {tool === 'route-planner' && <RoutePlanner/>}
             </Navbar.Collapse>

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import { AsyncTypeahead } from 'react-bootstrap-typeahead';
 import Navbar from 'react-bootstrap/lib/Navbar';
+import Button from 'react-bootstrap/lib/Button';
+import ButtonGroup from 'react-bootstrap/lib/ButtonGroup';
+import Glyphicon from 'react-bootstrap/lib/Glyphicon';
 import { connect } from 'react-redux';
-
 import { doSearch, highlightResult, selectResult } from 'fm3/actions/searchActions';
 import 'fm3/styles/search.scss';
 
@@ -19,36 +21,51 @@ class Search extends React.Component {
     const b = (fn, ...args) => fn.bind(this, ...args);
 
     return (
-      <Navbar.Form pullLeft>
-        <AsyncTypeahead
-          labelKey="label"
-          useCache={false}
-          minLength={3}
-          delay={500}
-          ignoreDiacritics
-          onSearch={this.props.onDoSearch}
-          options={this.props.results}
-          searchText="Hľadám…"
-          placeholder="Brusno"
-          clearButton
-          onChange={b(this.onSelectionChange)}
-          emptyLabel={'Nenašli sa žiadne výsledky'}
-          renderMenuItemChildren={(result) => (
-            <div key={result.label + result.id}
-              onMouseEnter={b(this.onSuggestionHighlightChange, result)}
-              onMouseLeave={b(this.onSuggestionHighlightChange, null)}
-            >
-              <span>{result.tags.name} </span><br/>
-              <span>({result.geojson.type}, {result.tags.type})</span>
-            </div>
-          )}
-        />
-      </Navbar.Form>
+      <div>
+        <Navbar.Form pullLeft>
+          <AsyncTypeahead
+            labelKey="label"
+            useCache={false}
+            minLength={3}
+            delay={500}
+            ignoreDiacritics
+            onSearch={this.props.onDoSearch}
+            options={this.props.results}
+            searchText="Hľadám…"
+            placeholder="Brusno"
+            clearButton
+            onChange={b(this.onSelectionChange)}
+            emptyLabel={'Nenašli sa žiadne výsledky'}
+            renderMenuItemChildren={(result) => (
+              <div key={result.label + result.id}
+                onMouseEnter={b(this.onSuggestionHighlightChange, result)}
+                onMouseLeave={b(this.onSuggestionHighlightChange, null)}
+              >
+                <span>{result.tags.name} </span><br/>
+                <span>({result.geojson.type}, {result.tags.type})</span>
+              </div>
+            )}
+          />
+        </Navbar.Form>
+        {this.props.tool === 'search' && 
+          <Navbar.Form pullLeft>
+            <ButtonGroup>
+              <Button>
+                <Glyphicon glyph="triangle-right" style={{ color: '#32CD32' }}/> Navigovať odtiaľto
+              </Button>
+              <Button>
+                <Glyphicon glyph="record" style={{ color: '#FF6347' }}/> Navigovať sem
+              </Button>
+            </ButtonGroup>
+          </Navbar.Form>
+        }
+      </div>
     );
   }
 }
 
 Search.propTypes = {
+  tool: React.PropTypes.string,
   results: React.PropTypes.array.isRequired,
   onDoSearch: React.PropTypes.func.isRequired,
   onHiglightResult: React.PropTypes.func.isRequired,
@@ -57,7 +74,10 @@ Search.propTypes = {
 
 export default connect(
   function (state) {
-    return { results: state.search.results };
+    return { 
+      tool: state.map.tool,
+      results: state.search.results 
+    };
   },
   function (dispatch) {
     return {

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -94,14 +94,8 @@ export default connect(
       onHiglightResult(result) {
         dispatch(highlightResult(result));
       },
-      onSelectResult(result, currentTool) {
-        if (result && currentTool == null) {
-          // calling setTool('search') when tool is already search will
-          // cause the map to set tool to null :(
-          dispatch(setTool('search'));
-        } else if (!result) {
-          dispatch(setTool(null));
-        }
+      onSelectResult(result) {
+        result ? dispatch(setTool('search')) : dispatch(setTool(null));
         dispatch(selectResult(result));
       },
       onInitRoutePlannerWithStart(result) {

--- a/src/logic/searchLogic.js
+++ b/src/logic/searchLogic.js
@@ -1,6 +1,6 @@
 import { createLogic } from 'redux-logic';
 import { setResults } from 'fm3/actions/searchActions';
-import { refocusMap, setTool } from 'fm3/actions/mapActions';
+import { refocusMap } from 'fm3/actions/mapActions';
 
 const searchLogic = createLogic({
   type: 'SEARCH',
@@ -48,22 +48,7 @@ const refocusMapLogic = createLogic({
   }
 });
 
-const setToolLogic = createLogic({
-  type: 'SELECT_RESULT',
-  process({ getState }, dispatch) {
-    const selectedResult = getState().search.selectedResult;
-    const tool = selectedResult ? 'search' : null;
-
-    // FIXME: this is a hack to avoid Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the ReactClass component.
-    setTimeout(() => {
-      return dispatch(setTool(tool));
-    }, 100);
-  }
-});
-
-
 export default [
   searchLogic,
-  refocusMapLogic,
-  setToolLogic
+  refocusMapLogic
 ];

--- a/src/logic/searchLogic.js
+++ b/src/logic/searchLogic.js
@@ -1,6 +1,6 @@
 import { createLogic } from 'redux-logic';
 import { setResults } from 'fm3/actions/searchActions';
-import { refocusMap } from 'fm3/actions/mapActions';
+import { refocusMap, setTool } from 'fm3/actions/mapActions';
 
 const searchLogic = createLogic({
   type: 'SEARCH',
@@ -33,7 +33,7 @@ const searchLogic = createLogic({
 
 const refocusMapLogic = createLogic({
   type: 'HIGHLIGHT_RESULT',
-  process({ getState }) {
+  process({ getState }, dispatch) {
     const { search: { highlightedResult }, map: { zoom, bounds } } = getState();
 
     if (highlightedResult && bounds) {
@@ -42,13 +42,28 @@ const refocusMapLogic = createLogic({
       const leafletBounds = L.latLngBounds(southWest, northEast);
       const hLatLon = L.latLng(highlightedResult.lat, highlightedResult.lon);
       if (zoom < 13 || !leafletBounds.contains(hLatLon)) {
-        return refocusMap(highlightedResult.lat, highlightedResult.lon, 13);
+        return dispatch(refocusMap(highlightedResult.lat, highlightedResult.lon, 13));
       }
     }
   }
 });
 
+const setToolLogic = createLogic({
+  type: 'SELECT_RESULT',
+  process({ getState }, dispatch) {
+    const selectedResult = getState().search.selectedResult;
+    const tool = selectedResult ? 'search' : null;
+
+    // FIXME: this is a hack to avoid Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the ReactClass component.
+    setTimeout(() => {
+      return dispatch(setTool(tool));
+    }, 100);
+  }
+});
+
+
 export default [
   searchLogic,
-  refocusMapLogic
+  refocusMapLogic,
+  setToolLogic
 ];

--- a/src/logic/searchLogic.js
+++ b/src/logic/searchLogic.js
@@ -42,7 +42,7 @@ const refocusMapLogic = createLogic({
       const leafletBounds = L.latLngBounds(southWest, northEast);
       const hLatLon = L.latLng(highlightedResult.lat, highlightedResult.lon);
       if (zoom < 13 || !leafletBounds.contains(hLatLon)) {
-        return dispatch(refocusMap(highlightedResult.lat, highlightedResult.lon, 13));
+        dispatch(refocusMap(highlightedResult.lat, highlightedResult.lon, 13));
       }
     }
   }

--- a/src/reducers/mapReducer.js
+++ b/src/reducers/mapReducer.js
@@ -15,7 +15,7 @@ const initialState = {
 export default function map(state = initialState, action) {
   switch (action.type) {
     case 'SET_TOOL':
-      return update(state, { tool: { $set: action.tool === state.tool ? null : action.tool } } );
+      return update(state, { tool: { $set: action.tool } } );
     case 'RESET_MAP':
       return update(state, {
         tool: { $set: initialState.tool },

--- a/src/reducers/searchReducer.js
+++ b/src/reducers/searchReducer.js
@@ -9,6 +9,8 @@ const initialState = {
 
 export default function Search(state = initialState, action) {
   switch (action.type) {
+    case 'SET_TOOL':
+      return (action.tool == 'search') ? state : initialState;
     case 'SEARCH':
       return update(state, { query: { $set: action.query } });
     case 'SET_RESULTS':


### PR DESCRIPTION
pridal som feature ze ked zvolis vysledok vyhladavania tak sa ti v hornom menu ponuknu tlacitka "navigovat sem" a "navigovat odtialto" a po kliknuti sa to prepne na planovac.

dost ma zmiatlo spravanie `map.setTool`, ktore ked napr. `tool` je `search` a zavolas `setTool('search')`, tak to podla mna uplne neintiutivne nastavi tool na `null` (zatial co ja som cakal ze to necha na `search`). ale zrejme si na to mal nejaky dovod, takze som nemenil.

nie som si isty ci je pekne ze volam [viac dispatchov naraz](https://github.com/FreemapSlovakia/freemap-v3-react/blob/feature-27-add-search-content-actions/src/components/Search.js#L97).

zo zvedavosti som skusal dat tu logiku okolo prepinania nastroja do SearchLogic, nieco v style:

```
const setToolLogic = createLogic({
  type: 'SELECT_RESULT',
  process({ getState }, dispatch) {
    const selectedResult = getState().search.selectedResult;
    const tool = selectedResult ? 'search' : null;
    return dispatch(setTool(tool));
  }
});
```

lenze to hadze chybu 

```
Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the ReactClass component.
```

comu rozumiem, ale nenasiel som iny sposob ako sa toho varovania zbavit nez pouzit `setTimeout` na dispatch (co je skaredy hack).