### PR TITLE
#30: smarter map refocus on search results

### DIFF
--- a/src/geoutils.js
+++ b/src/geoutils.js
@@ -22,3 +22,41 @@ export function bearing(lat1, lon1, lat2, lon2) {
 export function toRad(deg) {
   return deg * Math.PI / 180;
 }
+
+function dimensionsOf(geojson) {
+  const bounds = L.geoJson(geojson).getBounds();
+  const north = bounds.getNorth();
+  const west = bounds.getWest();
+  const south = bounds.getSouth();
+  const east = bounds.getEast();
+  
+  const northToSouthMeters = distance(north, west, south, west);
+  const westToEastMeters = distance(north, west, north, east);
+  
+  return { northToSouthMeters, westToEastMeters };
+}
+
+export function zoomLevelToFit(geojson) { // for Slovakia
+  const { northToSouthMeters, westToEastMeters } = dimensionsOf(geojson);
+  const largerDimension = (northToSouthMeters > westToEastMeters) ? northToSouthMeters : westToEastMeters;
+  const maxMeters = 600;
+  if (largerDimension < maxMeters) {
+    return 16;
+  }
+  if (largerDimension < maxMeters*2) {
+    return 15;
+  }  
+  if (largerDimension < maxMeters*4) {
+    return 14;
+  } 
+  if (largerDimension < maxMeters*8) {
+    return 13;
+  }
+  if (largerDimension < maxMeters*16) {
+    return 12;
+  }
+  if (largerDimension < maxMeters*32) {
+    return 11;
+  }
+  return 10;
+}


### PR DESCRIPTION
Martin, ak si najdes cas, daj vediet ci sa ti pozdava takyto refocus mapy pre vysledky vyhladavania:
* pre Points to funguje ako doteraz (zoom level 13)
* pre polygons/polylines to prisposobuje zoom level aby bolo dobre vidiet aj vysledok, aj okolie.

nepouzil som leaflet map.fitBounds, lebo to by som musel trochu viac prerabat react stavovy stroj a mal som obavy ako by to cele dopadlo. ten moj algoritmus fit-to-zoom som sa snazil nechat co najjednoduchsi, aby pokryl vacsinu pripadov (a neriesim polygony o velkosti SR).