### PR TITLE
fix #361: Pressing clear button wont remove toast

### DIFF
--- a/src/reducers/mapDetailsReducer.js
+++ b/src/reducers/mapDetailsReducer.js
@@ -9,6 +9,8 @@ const initialState = {
 
 export default function mapDetails(state = initialState, action) {
   switch (action.type) {
+    case at.CLEAR_MAP:
+      return initialState;
     case at.MAP_DETAILS_SET_SUBTOOL:
       return { ...state, subtool: action.payload.subtool };
     case at.MAP_DETAILS_SET_USER_SELECTED_POSITION:

--- a/src/reducers/toastsReducer.js
+++ b/src/reducers/toastsReducer.js
@@ -6,6 +6,10 @@ const initialState = {
 
 export default function toasts(state = initialState, action) {
   switch (action.type) {
+    case at.CLEAR_MAP:
+      return initialState;
+    case at.SET_TOOL:
+      return initialState;
     case at.TOASTS_ADD: {
       const { collapseKey } = action.payload;
       if (collapseKey) {


### PR DESCRIPTION
v kontexte nastroja Detaily v mape to robi nasledovne:
* ked je nastroj aktivny, a nejaka cesta je oznacena a toast viditelny, a stlacis tlacidlo Clear, cesta sa odznaci a toast zmizne
* ked je nastroj aktivny, a nejaka cesta je oznacena a toast viditelny a zavries nastroj (x), cesta sa odznaci a toast zmizne.