### PR TITLE
Fix a typo

### DIFF
--- a/src/osm/osmTagToNameMapping-en.ts
+++ b/src/osm/osmTagToNameMapping-en.ts
@@ -359,7 +359,7 @@ export const osmTagToNameMapping: OsmTagToNameMapping = {
     park: 'Park',
     picnic_table: {
       '*': 'Picnic table',
-      covered: { yes: 'Coverec picnic table' },
+      covered: { yes: 'Covered picnic table' },
     },
     pitch: {
       '*': 'Pitch',


### PR DESCRIPTION
While browsing the map, I realized there is a typo in "Covered picnic table".
So this PR fixes that.