### PR TITLE
Pridané nastavenia čiary pre GPX trasy

### DIFF
--- a/src/app/components/Main.tsx
+++ b/src/app/components/Main.tsx
@@ -305,6 +305,12 @@ const predefinedDrawingPropertiesModalFactory = () =>
     './PredefinedDrawingPropertiesModal.js'
   );
 
+const trackViewerLineStyleModalFactory = () =>
+  import(
+    /* webpackChunkName: "track-line-style-modal" */
+    '@features/trackViewer/components/TrackViewerLineStyleModal.js'
+  );
+
 export function Main(): ReactElement {
   const m = useMessages();
 
@@ -870,6 +876,11 @@ export function Main(): ReactElement {
       <AsyncModal
         show={activeModal === 'drawing-properties'}
         factory={predefinedDrawingPropertiesModalFactory}
+      />
+
+      <AsyncModal
+        show={activeModal === 'track-line-style'}
+        factory={trackViewerLineStyleModalFactory}
       />
 
       <GalleryModals />

--- a/src/app/store/actions.ts
+++ b/src/app/store/actions.ts
@@ -77,6 +77,7 @@ export const ModalSchema = z.enum([
   ...BASIC_MODALS,
   'tips',
   'current-drawing-properties',
+  'track-line-style',
 ]);
 
 export type Modal = z.infer<typeof ModalSchema>;

--- a/src/features/trackViewer/components/TrackViewerLineStyleModal.tsx
+++ b/src/features/trackViewer/components/TrackViewerLineStyleModal.tsx
@@ -1,0 +1,109 @@
+import { setActiveModal } from '@app/store/actions.js';
+import { DrawingRecentColors } from '@features/drawing/components/DrawingRecentColors.js';
+import { useMessages } from '@features/l10n/l10nInjector.js';
+import { useAppSelector } from '@shared/hooks/useAppSelector.js';
+import { ReactElement, SubmitEvent, useCallback, useState } from 'react';
+import { Button, Form, Modal } from 'react-bootstrap';
+import { FaCheck, FaTimes } from 'react-icons/fa';
+import { useDispatch } from 'react-redux';
+import { trackViewerSetLineStyle } from '../model/actions.js';
+
+type Props = { show: boolean };
+
+export default TrackViewerLineStyleModal;
+
+export function TrackViewerLineStyleModal({ show }: Props): ReactElement {
+  const m = useMessages();
+
+  const dispatch = useDispatch();
+
+  const lineColor = useAppSelector((state) => state.trackViewer.lineColor);
+
+  const lineWidth = useAppSelector((state) => state.trackViewer.lineWidth);
+
+  const [editedColor, setEditedColor] = useState(lineColor);
+
+  const [editedWidth, setEditedWidth] = useState(String(lineWidth));
+
+  const close = useCallback(() => {
+    dispatch(setActiveModal(null));
+  }, [dispatch]);
+
+  const handleSubmit = (e: SubmitEvent) => {
+    e.preventDefault();
+
+    dispatch(
+      trackViewerSetLineStyle({
+        lineColor: editedColor,
+        lineWidth: Number(editedWidth) || 6,
+      }),
+    );
+
+    dispatch(setActiveModal(null));
+  };
+
+  const widthNum = parseFloat(editedWidth) || 6;
+
+  const previewHeight = Math.max(20, widthNum + 12);
+
+  return (
+    <Modal show={show} onHide={close}>
+      <Form onSubmit={handleSubmit}>
+        <Modal.Header closeButton>
+          <Modal.Title>{m?.trackViewer.lineStyle.title}</Modal.Title>
+        </Modal.Header>
+
+        <Modal.Body>
+          <Form.Group controlId="trackLineColor" className="mt-3">
+            <Form.Label>{m?.drawing.edit.color}</Form.Label>
+
+            <Form.Control
+              type="color"
+              value={editedColor}
+              onChange={(e) => setEditedColor(e.currentTarget.value)}
+            />
+
+            <DrawingRecentColors onColor={setEditedColor} />
+          </Form.Group>
+
+          <Form.Group controlId="trackLineWidth" className="mt-3">
+            <Form.Label>{m?.drawing.edit.width}</Form.Label>
+
+            <Form.Control
+              type="number"
+              value={editedWidth}
+              min={1}
+              max={20}
+              onChange={(e) => setEditedWidth(e.currentTarget.value)}
+            />
+          </Form.Group>
+
+          <Form.Group controlId="trackLinePreview" className="mt-3">
+            <svg width="100%" height={previewHeight} style={{ display: 'block' }}>
+              <line
+                x1="4"
+                y1="50%"
+                x2="96%"
+                y2="50%"
+                stroke={editedColor}
+                strokeWidth={widthNum}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </Form.Group>
+        </Modal.Body>
+
+        <Modal.Footer>
+          <Button type="submit">
+            <FaCheck /> {m?.general.save}
+          </Button>
+
+          <Button variant="dark" type="button" onClick={close}>
+            <FaTimes /> {m?.general.cancel}
+          </Button>
+        </Modal.Footer>
+      </Form>
+    </Modal>
+  );
+}

--- a/src/features/trackViewer/components/TrackViewerMenu.tsx
+++ b/src/features/trackViewer/components/TrackViewerMenu.tsx
@@ -18,6 +18,7 @@ import {
   FaCloudUploadAlt,
   FaInfoCircle,
   FaPaintBrush,
+  FaPalette,
   FaPencilAlt,
   FaUpload,
 } from 'react-icons/fa';
@@ -173,6 +174,25 @@ export function TrackViewerMenu(): ReactElement {
               {...props}
             >
               <FaCloudUploadAlt />
+              <span className={labelClassName}> {label}</span>
+            </Button>
+          )}
+        </LongPressTooltip>
+      )}
+
+      {hasTrack && (
+        <LongPressTooltip
+          breakpoint="sm"
+          label={m?.trackViewer.lineStyle.menuItem}
+        >
+          {({ label, labelClassName, props }) => (
+            <Button
+              className="ms-1"
+              variant="secondary"
+              onClick={() => dispatch(setActiveModal('track-line-style'))}
+              {...props}
+            >
+              <FaPalette />
               <span className={labelClassName}> {label}</span>
             </Button>
           )}

--- a/src/features/trackViewer/components/TrackViewerResult.tsx
+++ b/src/features/trackViewer/components/TrackViewerResult.tsx
@@ -43,6 +43,10 @@ export function TrackViewerResult({
     (state) => state.trackViewer.colorizeTrackBy,
   );
 
+  const lineColor = useAppSelector((state) => state.trackViewer.lineColor);
+
+  const lineWidth = useAppSelector((state) => state.trackViewer.lineWidth);
+
   const eleSmoothingFactor = 5;
 
   const getFeatures: GetFeatures = (type: 'LineString' | 'Point') =>
@@ -121,7 +125,7 @@ export function TrackViewerResult({
       {features.map(({ lineData, name }, i) => (
         <Polyline
           key={`outline-${i}-${interactive ? 'a' : 'b'}`}
-          weight={10}
+          weight={lineWidth + 4}
           interactive={interactive}
           positions={lineData}
           color="#fff"
@@ -150,7 +154,7 @@ export function TrackViewerResult({
             getLat={(p) => p.point.lat}
             getLng={(p) => p.point.lon}
             options={{
-              weight: 6,
+              weight: lineWidth,
               outlineWidth: 0,
               palette:
                 colorizeTrackBy === 'elevation'
@@ -171,10 +175,10 @@ export function TrackViewerResult({
       {colorizeTrackBy === null && (
         <Polyline
           key={`poly-${interactive ? 'a' : 'b'}`}
-          weight={6}
+          weight={lineWidth}
           interactive={interactive}
           positions={features.map(({ lineData }) => lineData)}
-          color="#838"
+          color={lineColor}
           bubblingMouseEvents={false}
           eventHandlers={{
             click: setThisTool,

--- a/src/features/trackViewer/model/actions.ts
+++ b/src/features/trackViewer/model/actions.ts
@@ -40,3 +40,8 @@ export const trackViewerToggleElevationChart = createAction(
 export const trackViewerGpxLoad = createAction<string>('TRACK_VIEWER_GPX_LOAD');
 
 export const trackViewerDelete = createAction('TRACK_VIEWER_DELETE');
+
+export const trackViewerSetLineStyle = createAction<{
+  lineColor?: string;
+  lineWidth?: number;
+}>('TRACK_VIEWER_SET_LINE_STYLE');

--- a/src/features/trackViewer/model/reducer.ts
+++ b/src/features/trackViewer/model/reducer.ts
@@ -9,6 +9,7 @@ import {
   trackViewerDownloadTrack,
   trackViewerGpxLoad,
   trackViewerSetData,
+  trackViewerSetLineStyle,
   trackViewerSetTrackUID,
 } from './actions.js';
 
@@ -21,6 +22,8 @@ export interface TrackViewerStateBase {
 
 export interface TrackViewerState extends TrackViewerStateBase {
   colorizeTrackBy: null | 'elevation' | 'steepness';
+  lineColor: string;
+  lineWidth: number;
 }
 
 export const cleanState: TrackViewerStateBase = {
@@ -32,6 +35,8 @@ export const cleanState: TrackViewerStateBase = {
 
 export const trackViewerInitialState: TrackViewerState = {
   colorizeTrackBy: null,
+  lineColor: '#838',
+  lineWidth: 6,
   ...cleanState,
 };
 
@@ -57,6 +62,14 @@ export const trackViewerReducer = createReducer(
       })
       .addCase(trackViewerColorizeTrackBy, (state, action) => {
         state.colorizeTrackBy = action.payload;
+      })
+      .addCase(trackViewerSetLineStyle, (state, action) => {
+        if (action.payload.lineColor !== undefined) {
+          state.lineColor = action.payload.lineColor;
+        }
+        if (action.payload.lineWidth !== undefined) {
+          state.lineWidth = action.payload.lineWidth;
+        }
       })
       .addCase(trackViewerGpxLoad, (state, action) => {
         state.gpxUrl = action.payload;

--- a/src/translations/cs.template.tsx
+++ b/src/translations/cs.template.tsx
@@ -461,6 +461,10 @@ const messages: DeepPartialWithRequiredObjects<Messages> = {
     upload: 'Nahrát',
     moreInfo: 'Více info',
     share: 'Uložit na server',
+    lineStyle: {
+      menuItem: 'Styl trasy',
+      title: 'Styl čáry trasy',
+    },
     colorizingMode: {
       none: 'Neaktivní',
       elevation: 'Nadmořská výška',

--- a/src/translations/en.tsx
+++ b/src/translations/en.tsx
@@ -463,6 +463,10 @@ const messages: Messages = {
     upload: 'Upload',
     moreInfo: 'More info',
     share: 'Save on server',
+    lineStyle: {
+      menuItem: 'Track style',
+      title: 'Track line style',
+    },
     colorizingMode: {
       none: 'Inactive',
       elevation: 'Elevation',

--- a/src/translations/messagesInterface.ts
+++ b/src/translations/messagesInterface.ts
@@ -335,6 +335,10 @@ export type Messages = {
     upload: string;
     moreInfo: string;
     share: string;
+    lineStyle: {
+      menuItem: string;
+      title: string;
+    };
     colorizingMode: {
       none: string;
       elevation: string;

--- a/src/translations/sk.template.tsx
+++ b/src/translations/sk.template.tsx
@@ -504,6 +504,10 @@ const messages: DeepPartialWithRequiredObjects<Messages> = {
     upload: 'Nahrať',
     moreInfo: 'Viac info',
     share: 'Uložiť na server',
+    lineStyle: {
+      menuItem: 'Štýl trasy',
+      title: 'Štýl čiary trasy',
+    },
     colorizingMode: {
       none: 'Neaktívne',
       elevation: 'Nadmorská výška',


### PR DESCRIPTION
actions.ts — pridaná nová akcia trackViewerSetLineStyle s parametrami lineColor a lineWidth

reducer.ts — pridané polia lineColor: string a lineWidth: number do stavu (predvolené: FreemapSlovakia/freemap-v3-nodejs-backend#50 a 6), handler pre novú akciu

TrackViewerResult.tsx — namiesto pevne zapísaných hodnôt (color="#838", weight={6}) sa teraz používajú hodnoty zo stavu; biela obrysová čiara sa dynamicky škáluje podľa lineWidth + 4

TrackViewerLineStyleModal.tsx — nový modal (podobný PredefinedDrawingPropertiesModal) s výberom farby (color picker + naposledy použité farby), hrúbky a SVG náhľadom

TrackViewerMenu.tsx — pridané tlačidlo FaPalette "Štýl trasy" (viditeľné keď je nahratá trasa), otvára nový modal

actions.ts (store) — pridaná 'track-line-style' do zoznamu modalov

Main.tsx — registrácia nového modalu cez AsyncModal s lazy loadingom

Preklady — pridané trackViewer.lineStyle.menuItem a trackViewer.lineStyle.title do EN, SK a CS jazykov