### PR TITLE
Unify modal/overlay state into a single activeModal + packed show= URL

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -64,22 +64,24 @@ and unified URL serialization through the packed `show=type/arg` codec
 (`encodeActiveModal`/`decodeShow` in `src/app/store/actions.ts`), with backward
 compat for `document=`/`tip=`/legacy `show=` renames.
 
-Phase 2 (done) routed the gallery viewer and the Wikimedia Commons preview
-through the same `show=` param (`show=gallery-viewer/<id>`, `show=wmc/<pageId>`),
+Phase 2 (done) routed the gallery viewer, the Wikimedia Commons preview, and the
+Wikipedia (`wiki`) preview through the same `show=` param
+(`show=gallery-viewer/<id>`, `show=wmc/<pageId>`, `show=wiki/<lang>:<title>`),
 dropping the bespoke `image=`/`wmc=` serialize/deserialize blocks (kept as legacy
 read-aliases). Their slice state (`gallery.activeImageId`,
-`wikimediaCommons.preview/loading`) is unchanged — only the URL layer was
-unified.
+`wikimediaCommons.preview/loading`, `wiki.preview/loading`) is unchanged — only
+the URL layer was unified.
 
 Optional deeper cleanup (not required; `show=` is already the single param):
 
-- [ ] **Fold `gallery-viewer`/`wmc` state into `activeModal`.** Replace
-      `gallery.activeImageId` / `wikimediaCommons.preview` with
-      `activeModal.type === 'gallery-viewer' | 'wmc'` as the source of truth. Needs
-      moving the `next`/`prev` resolution out of the `galleryRequestImage` reducer
-      into a processor, and updating `showGalleryViewerSelector`,
-      `GalleryViewerModal`, and the gallery delete/stars/comment processors. Higher
-      churn, no user-visible change — only do it if the dual state becomes a problem.
+- [ ] **Fold `gallery-viewer`/`wmc`/`wiki` state into `activeModal`.** Replace
+      `gallery.activeImageId` / `wikimediaCommons.preview` / `wiki.preview` with
+      `activeModal.type === 'gallery-viewer' | 'wmc' | 'wiki'` as the source of
+      truth. Needs moving the `next`/`prev` resolution out of the
+      `galleryRequestImage` reducer into a processor, and updating
+      `showGalleryViewerSelector`, `GalleryViewerModal`, and the gallery
+      delete/stars/comment processors. Higher churn, no user-visible change — only
+      do it if the dual state becomes a problem.
 - [ ] **Delete dead `src/features/documents/model/reducer.ts`.** Its `documentKey`
       slice is not wired into `rootReducer`; the document overlay now lives in
       `activeModal`.

--- a/TODO.md
+++ b/TODO.md
@@ -55,6 +55,32 @@ Project-review findings (2026-06-08). Roughly ordered by payoff. See
       it would let many hand-written `useMemo`/`useCallback` be dropped, changing
       how much manual hook churn is worthwhile).
 
+## Modal/overlay state unification — Phase 2
+
+Phase 1 (done) made `state.main.activeModal` a `Selection`-like discriminated
+union `{ type; …args } | null`, folded the `document` overlay into it, drove the
+watched-device form from `activeModal.token` (removed `modifiedTrackedDevice`),
+and unified URL serialization through the packed `show=type/arg` codec
+(`encodeActiveModal`/`decodeShow` in `src/app/store/actions.ts`), with backward
+compat for `document=`/`tip=`/legacy `show=` renames.
+
+- [ ] **Fold `gallery-viewer` into `activeModal`.** Replace `gallery.activeImageId`
+      with `activeModal.type === 'gallery-viewer'` (id arg). Move the `next`/`prev`
+      resolution out of the `galleryRequestImage` reducer into
+      `galleryRequestImageProcessor`; it dispatches `setActiveModal({type:'gallery-viewer', id})`
+      then fetches. Update `showGalleryViewerSelector`, the delete/stars/comment
+      processors, and `GalleryViewerModal`. Drop the bespoke `image=` serialize
+      block in `urlProcessor.ts` and the `image=` deserialize in
+      `locationChangeHandler.ts` (now handled by the unified codec — already in
+      `decodeShow`/`encodeActiveModal`).
+- [ ] **Fold `wmc` into `activeModal`.** Modal show → `activeModal.type === 'wmc'`
+      (pageId arg). `wikimediaCommonsLoadPreview` also dispatches
+      `setActiveModal({type:'wmc', pageId})`; `preview`/`loading` stay fetch status.
+      Drop the `wmc=` serialize/deserialize blocks (handled by the codec).
+- [ ] **Delete dead `src/features/documents/model/reducer.ts`.** Its `documentKey`
+      slice is not wired into `rootReducer`; the document overlay now lives in
+      `activeModal`.
+
 ## Premium / monetization
 
 Context: payment provider (Polar) acceptable-use rules and content licensing

--- a/TODO.md
+++ b/TODO.md
@@ -55,7 +55,7 @@ Project-review findings (2026-06-08). Roughly ordered by payoff. See
       it would let many hand-written `useMemo`/`useCallback` be dropped, changing
       how much manual hook churn is worthwhile).
 
-## Modal/overlay state unification — Phase 2
+## Modal/overlay state unification
 
 Phase 1 (done) made `state.main.activeModal` a `Selection`-like discriminated
 union `{ type; …args } | null`, folded the `document` overlay into it, drove the
@@ -64,19 +64,22 @@ and unified URL serialization through the packed `show=type/arg` codec
 (`encodeActiveModal`/`decodeShow` in `src/app/store/actions.ts`), with backward
 compat for `document=`/`tip=`/legacy `show=` renames.
 
-- [ ] **Fold `gallery-viewer` into `activeModal`.** Replace `gallery.activeImageId`
-      with `activeModal.type === 'gallery-viewer'` (id arg). Move the `next`/`prev`
-      resolution out of the `galleryRequestImage` reducer into
-      `galleryRequestImageProcessor`; it dispatches `setActiveModal({type:'gallery-viewer', id})`
-      then fetches. Update `showGalleryViewerSelector`, the delete/stars/comment
-      processors, and `GalleryViewerModal`. Drop the bespoke `image=` serialize
-      block in `urlProcessor.ts` and the `image=` deserialize in
-      `locationChangeHandler.ts` (now handled by the unified codec — already in
-      `decodeShow`/`encodeActiveModal`).
-- [ ] **Fold `wmc` into `activeModal`.** Modal show → `activeModal.type === 'wmc'`
-      (pageId arg). `wikimediaCommonsLoadPreview` also dispatches
-      `setActiveModal({type:'wmc', pageId})`; `preview`/`loading` stay fetch status.
-      Drop the `wmc=` serialize/deserialize blocks (handled by the codec).
+Phase 2 (done) routed the gallery viewer and the Wikimedia Commons preview
+through the same `show=` param (`show=gallery-viewer/<id>`, `show=wmc/<pageId>`),
+dropping the bespoke `image=`/`wmc=` serialize/deserialize blocks (kept as legacy
+read-aliases). Their slice state (`gallery.activeImageId`,
+`wikimediaCommons.preview/loading`) is unchanged — only the URL layer was
+unified.
+
+Optional deeper cleanup (not required; `show=` is already the single param):
+
+- [ ] **Fold `gallery-viewer`/`wmc` state into `activeModal`.** Replace
+      `gallery.activeImageId` / `wikimediaCommons.preview` with
+      `activeModal.type === 'gallery-viewer' | 'wmc'` as the source of truth. Needs
+      moving the `next`/`prev` resolution out of the `galleryRequestImage` reducer
+      into a processor, and updating `showGalleryViewerSelector`,
+      `GalleryViewerModal`, and the gallery delete/stars/comment processors. Higher
+      churn, no user-visible change — only do it if the dual state becomes a problem.
 - [ ] **Delete dead `src/features/documents/model/reducer.ts`.** Its `documentKey`
       slice is not wired into `rootReducer`; the document overlay now lives in
       `activeModal`.

--- a/src/app/components/CopyrightButton.tsx
+++ b/src/app/components/CopyrightButton.tsx
@@ -81,7 +81,7 @@ export function CopyrightButton(): ReactElement {
               onClick={(e) => {
                 e.preventDefault();
 
-                dispatch(setActiveModal('legend'));
+                dispatch(setActiveModal({ type: 'legend' }));
               }}
             >
               <FaList /> {m?.mainMenu.mapLegend} <kbd>m</kbd> <kbd>l</kbd>

--- a/src/app/components/Layers.tsx
+++ b/src/app/components/Layers.tsx
@@ -67,7 +67,7 @@ export function Layers(): ReactElement | null {
   const dispatch = useDispatch();
 
   const handlePremiumClick = useCallback(() => {
-    dispatch(setActiveModal('premium'));
+    dispatch(setActiveModal({ type: 'premium' }));
   }, [dispatch]);
 
   function getLayer(layerDef: LayerDef) {

--- a/src/app/components/Main.tsx
+++ b/src/app/components/Main.tsx
@@ -596,8 +596,6 @@ export function Main(): ReactElement {
     (state) => state.homeLocation.selectingHomeLocation,
   );
 
-  const documentKey = useAppSelector((state) => state.main.documentKey);
-
   const showPosition = useAppSelector((state) => state.gallery.showPosition);
 
   const pickingPosition = useAppSelector(
@@ -641,9 +639,7 @@ export function Main(): ReactElement {
                   {(!window.fmEmbedded || embedFeatures.includes('search')) && (
                     <SearchMenu
                       hidden={!showMenu}
-                      preventShortcut={
-                        Boolean(activeModal) || Boolean(documentKey)
-                      }
+                      preventShortcut={Boolean(activeModal)}
                     />
                   )}
                 </Toolbar>
@@ -856,109 +852,118 @@ export function Main(): ReactElement {
           [
             ...(isUserValidated ? ['tracking-my'] : []),
             'tracking-watched',
-          ].includes(activeModal)
+          ].includes(activeModal.type)
         }
         factory={trackingModalFactory}
       />
 
       <AsyncModal
-        show={activeModal === 'account'}
+        show={activeModal?.type === 'account'}
         factory={accountModalFactory}
       />
 
       <AsyncModal
-        show={activeModal === 'offline-map-export'}
+        show={activeModal?.type === 'offline-map-export'}
         factory={downloadMapModalFactory}
       />
 
       <AsyncModal
-        show={activeModal === 'offline-maps'}
+        show={activeModal?.type === 'offline-maps'}
         factory={cachedMapsModalFactory}
       />
 
       <AsyncModal
-        show={activeModal === 'map-layers-config'}
+        show={activeModal?.type === 'map-layers-config'}
         factory={mapLayersConfigModalFactory}
       />
 
       <AsyncModal
-        show={activeModal === 'custom-maps'}
+        show={activeModal?.type === 'custom-maps'}
         factory={customMapsModalFactory}
       />
 
       <AsyncModal
-        show={activeModal === 'map-preferences'}
+        show={activeModal?.type === 'map-preferences'}
         factory={mapPreferencesModalFactory}
       />
 
       <AsyncModal
-        show={activeModal === 'embed'}
+        show={activeModal?.type === 'embed'}
         factory={embedMapModalFactory}
       />
 
       <AsyncModal
-        show={activeModal === 'map-features-export'}
+        show={activeModal?.type === 'map-features-export'}
         factory={exportGpxModalFactory}
       />
 
       <AsyncModal
-        show={activeModal === 'map-to-document-export'}
+        show={activeModal?.type === 'map-to-document-export'}
         factory={exportMapModalFactory}
       />
 
       <AsyncModal
-        show={!activeModal && documentKey !== null}
+        show={activeModal?.type === 'document'}
         factory={documentModalFactory}
       />
 
-      <AsyncModal show={activeModal === 'about'} factory={aboutModalFactory} />
+      <AsyncModal
+        show={activeModal?.type === 'about'}
+        factory={aboutModalFactory}
+      />
 
       <AsyncModal
-        show={activeModal === 'credits-purchase'}
+        show={activeModal?.type === 'credits-purchase'}
         factory={buyCreditModalFactory}
       />
 
       <AsyncModal
-        show={activeModal === 'support-us'}
+        show={activeModal?.type === 'support-us'}
         factory={supportUsModalFactory}
       />
 
       <AsyncModal
-        show={activeModal === 'legend'}
+        show={activeModal?.type === 'legend'}
         factory={legendModalFactory}
       />
 
       <AsyncModal
-        show={activeModal === 'current-drawing-properties'}
+        show={activeModal?.type === 'current-drawing-properties'}
         factory={currentDrawingPropertiesModalFactory}
       />
 
       <AsyncModal
-        show={activeModal === 'file-import'}
+        show={activeModal?.type === 'file-import'}
         factory={trackViewerUploadModalFactory}
       />
 
-      <AsyncModal show={activeModal === 'login'} factory={loginModalFactory} />
-
-      <AsyncModal show={activeModal === 'my-maps'} factory={mapsModalFactory} />
+      <AsyncModal
+        show={activeModal?.type === 'login'}
+        factory={loginModalFactory}
+      />
 
       <AsyncModal
-        show={activeModal === 'premium'}
+        show={activeModal?.type === 'my-maps'}
+        factory={mapsModalFactory}
+      />
+
+      <AsyncModal
+        show={activeModal?.type === 'premium'}
         factory={premiumActivationModalFactory}
       />
 
       <AsyncModal
-        show={activeModal === 'gallery-filter'}
+        show={activeModal?.type === 'gallery-filter'}
         factory={galleryFilterModalFactory}
       />
 
       <AsyncModal
-        show={activeModal === 'gallery-leaderboard'}
+        show={activeModal?.type === 'gallery-leaderboard'}
         factory={galleryLeaderboardModalFactory}
       />
 
       <AsyncModal
-        show={activeModal === 'drawing-properties'}
+        show={activeModal?.type === 'drawing-properties'}
         factory={predefinedDrawingPropertiesModalFactory}
       />
 

--- a/src/app/components/Main.tsx
+++ b/src/app/components/Main.tsx
@@ -505,7 +505,7 @@ export function Main(): ReactElement {
       );
 
       if (pictureFiles.length) {
-        dispatch(setActiveModal('gallery-upload')); // if no user then it displays valuable error
+        dispatch(setActiveModal({ type: 'gallery-upload' })); // if no user then it displays valuable error
 
         if (authenticated) {
           handlePicturesDrop(pictureFiles);

--- a/src/app/components/MapSwitchButton.tsx
+++ b/src/app/components/MapSwitchButton.tsx
@@ -125,7 +125,7 @@ export function MapSwitchButton(): ReactElement {
         }
 
         if (x instanceof SVGElement && x.dataset['filter']) {
-          dispatch(setActiveModal('gallery-filter'));
+          dispatch(setActiveModal({ type: 'gallery-filter' }));
 
           return true;
         }
@@ -149,7 +149,7 @@ export function MapSwitchButton(): ReactElement {
 
         dispatch(cachedMapsSetView('list'));
 
-        dispatch(setActiveModal('offline-maps'));
+        dispatch(setActiveModal({ type: 'offline-maps' }));
       } else if (eventKey.startsWith('layer-')) {
         dispatch(mapToggleLayer({ type: eventKey.slice(6) }));
       } else {

--- a/src/app/keyboardHandler.ts
+++ b/src/app/keyboardHandler.ts
@@ -251,7 +251,7 @@ function handleEvent(event: KeyboardEvent, state: RootState) {
       }
 
       if (event.code === 'KeyM') {
-        return setActiveModal('my-maps');
+        return setActiveModal({ type: 'my-maps' });
       }
 
       const toolDefinition = toolDefinitions.find(
@@ -263,11 +263,11 @@ function handleEvent(event: KeyboardEvent, state: RootState) {
       }
 
       if (event.code === 'KeyW') {
-        return setActiveModal('tracking-watched');
+        return setActiveModal({ type: 'tracking-watched' });
       }
 
       if (event.code === 'KeyD') {
-        return setActiveModal('tracking-my');
+        return setActiveModal({ type: 'tracking-my' });
       }
 
       return undefined;
@@ -319,13 +319,13 @@ function handleEvent(event: KeyboardEvent, state: RootState) {
           return galleryList('-createdAt');
 
         case 'KeyU':
-          return setActiveModal('gallery-upload');
+          return setActiveModal({ type: 'gallery-upload' });
 
         case 'KeyF':
-          return setActiveModal('gallery-filter');
+          return setActiveModal({ type: 'gallery-filter' });
 
         case 'KeyB':
-          return setActiveModal('gallery-leaderboard');
+          return setActiveModal({ type: 'gallery-leaderboard' });
 
         default:
           return undefined;
@@ -335,22 +335,22 @@ function handleEvent(event: KeyboardEvent, state: RootState) {
     if (initCode === 'KeyE') {
       switch (event.code) {
         case 'KeyA':
-          return setActiveModal('account');
+          return setActiveModal({ type: 'account' });
 
         case 'KeyG':
-          return setActiveModal('map-features-export');
+          return setActiveModal({ type: 'map-features-export' });
 
         case 'KeyP':
-          return setActiveModal('map-to-document-export');
+          return setActiveModal({ type: 'map-to-document-export' });
 
         case 'KeyE':
-          return setActiveModal('embed');
+          return setActiveModal({ type: 'embed' });
 
         case 'KeyD':
-          return setActiveModal('drawing-properties');
+          return setActiveModal({ type: 'drawing-properties' });
 
         case 'KeyM':
-          return setActiveModal('offline-map-export');
+          return setActiveModal({ type: 'offline-map-export' });
       }
 
       return undefined;
@@ -359,19 +359,19 @@ function handleEvent(event: KeyboardEvent, state: RootState) {
     if (initCode === 'KeyM') {
       switch (event.code) {
         case 'KeyP':
-          return setActiveModal('map-preferences');
+          return setActiveModal({ type: 'map-preferences' });
 
         case 'KeyO':
-          return setActiveModal('offline-maps');
+          return setActiveModal({ type: 'offline-maps' });
 
         case 'KeyY':
-          return setActiveModal('map-layers-config');
+          return setActiveModal({ type: 'map-layers-config' });
 
         case 'KeyC':
-          return setActiveModal('custom-maps');
+          return setActiveModal({ type: 'custom-maps' });
 
         case 'KeyL':
-          return setActiveModal('legend');
+          return setActiveModal({ type: 'legend' });
       }
 
       return undefined;

--- a/src/app/keyboardHandler.ts
+++ b/src/app/keyboardHandler.ts
@@ -44,12 +44,17 @@ function handleEvent(event: KeyboardEvent, state: RootState) {
     state.gallery.showPosition ||
     state.mapArea.selecting;
 
+  // Overlays that own their open-state outside main.activeModal: the gallery
+  // viewer, and the Wikimedia Commons / Wikipedia previews (each shown while
+  // loading or once previewed). The picking/selecting overlays are tracked by
+  // `suspendedModal` instead.
   const showingModal =
-    Boolean(state.main.activeModal) || Boolean(state.gallery.activeImageId);
-  //  ||
-  // state.homeLocation.selectingHomeLocation ||
-  // state.gallery.pickingPositionForId ||
-  // state.gallery.showPosition;
+    Boolean(state.main.activeModal) ||
+    Boolean(state.gallery.activeImageId) ||
+    Boolean(state.wikimediaCommons.preview) ||
+    Boolean(state.wikimediaCommons.loading) ||
+    Boolean(state.wiki.preview) ||
+    Boolean(state.wiki.loading);
 
   if (!withModifiers && event.code === 'Escape') {
     if (document.querySelector('*[aria-expanded=true]') !== null) {

--- a/src/app/keyboardHandler.ts
+++ b/src/app/keyboardHandler.ts
@@ -45,9 +45,7 @@ function handleEvent(event: KeyboardEvent, state: RootState) {
     state.mapArea.selecting;
 
   const showingModal =
-    Boolean(state.main.activeModal) ||
-    Boolean(state.gallery.activeImageId) ||
-    Boolean(state.main.documentKey);
+    Boolean(state.main.activeModal) || Boolean(state.gallery.activeImageId);
   //  ||
   // state.homeLocation.selectingHomeLocation ||
   // state.gallery.pickingPositionForId ||

--- a/src/app/store/actions.ts
+++ b/src/app/store/actions.ts
@@ -4,6 +4,10 @@ import {
   setAnalyticCookiesAllowed,
 } from '@features/cookieConsent/model/actions.js';
 import {
+  type Document,
+  DocumentSchema,
+} from '@features/documents/model/actions.js';
+import {
   saveHomeLocation,
   setSelectingHomeLocation,
 } from '@features/homeLocation/model/actions.js';
@@ -57,26 +61,21 @@ const BASIC_MODALS = [
 
 export const ShowModalSchema = z.enum(BASIC_MODALS);
 
-export const ShowModalCompatSchema = z.preprocess(
-  (v) =>
-    (typeof v === 'string' &&
-      ({
-        'export-map': 'map-to-document-export',
-        'export-gpx': 'map-features-export',
-        'export-map-features': 'map-features-export',
-        'export-pdf': 'map-to-document-export',
-        'download-map': 'offline-map-export',
-        supportUs: 'support-us',
-        mapSettings: 'map-layers-config',
-        'map-settings': 'map-layers-config',
-        'remove-ads': 'premium',
-        'upload-track': 'file-import',
-        'buy-credits': 'credits-purchase',
-        maps: 'my-maps',
-      }[v] as string | undefined)) ||
-    v,
-  ShowModalSchema,
-);
+/** Legacy modal ids (from old shared links) mapped to their current name. */
+const MODAL_RENAMES: Record<string, string> = {
+  'export-map': 'map-to-document-export',
+  'export-gpx': 'map-features-export',
+  'export-map-features': 'map-features-export',
+  'export-pdf': 'map-to-document-export',
+  'download-map': 'offline-map-export',
+  supportUs: 'support-us',
+  mapSettings: 'map-layers-config',
+  'map-settings': 'map-layers-config',
+  'remove-ads': 'premium',
+  'upload-track': 'file-import',
+  'buy-credits': 'credits-purchase',
+  maps: 'my-maps',
+};
 
 export const ModalSchema = z.enum([
   ...BASIC_MODALS,
@@ -87,6 +86,92 @@ export const ModalSchema = z.enum([
 export type Modal = z.infer<typeof ModalSchema>;
 
 export type ShowModal = z.infer<typeof ShowModalSchema>;
+
+/**
+ * The open modal/overlay. A discriminated union so a modal can carry an
+ * argument (e.g. the document key or watched-device token). At most one is open
+ * at a time. `null` means no modal.
+ */
+export type ActiveModal =
+  | { type: Exclude<Modal, 'tracking-watched'> }
+  | { type: 'tracking-watched'; token?: string }
+  | { type: 'document'; key: Document }
+  | { type: 'gallery-viewer'; id: number }
+  | { type: 'wmc'; pageId: number };
+
+/** Modal types that round-trip through the URL as `show=<type>[/<arg>]`. */
+const URL_SERIALIZABLE: ReadonlySet<string> = new Set(BASIC_MODALS);
+
+/**
+ * Serializes the open modal to the packed `show=` value (`type` or `type/arg`),
+ * or `null` when it has no URL representation. The literal `/` survives because
+ * `serializeQuery` un-escapes `%2F`.
+ */
+export function encodeActiveModal(modal: ActiveModal | null): string | null {
+  if (!modal) {
+    return null;
+  }
+
+  switch (modal.type) {
+    case 'tracking-watched':
+      return modal.token
+        ? `tracking-watched/${modal.token}`
+        : 'tracking-watched';
+    case 'document':
+      return `document/${modal.key}`;
+    case 'gallery-viewer':
+      return `gallery-viewer/${modal.id}`;
+    case 'wmc':
+      return `wmc/${modal.pageId}`;
+    default:
+      return URL_SERIALIZABLE.has(modal.type) ? modal.type : null;
+  }
+}
+
+/**
+ * Parses a packed `show=` value (`type` or `type/arg`) into an `ActiveModal`,
+ * applying legacy name renames. Returns `null` when nothing valid is named.
+ */
+export function decodeShow(raw: string): ActiveModal | null {
+  if (!raw) {
+    return null;
+  }
+
+  const slash = raw.indexOf('/');
+
+  const rawType = slash === -1 ? raw : raw.slice(0, slash);
+
+  const arg = slash === -1 ? undefined : raw.slice(slash + 1);
+
+  const type = MODAL_RENAMES[rawType] ?? rawType;
+
+  switch (type) {
+    case 'tracking-watched':
+      return arg
+        ? { type: 'tracking-watched', token: arg }
+        : { type: 'tracking-watched' };
+    case 'document': {
+      const r = DocumentSchema.safeParse(arg);
+
+      return r.success ? { type: 'document', key: r.data } : null;
+    }
+    case 'gallery-viewer': {
+      const id = Number(arg);
+
+      return arg && Number.isFinite(id) ? { type: 'gallery-viewer', id } : null;
+    }
+    case 'wmc': {
+      const pageId = Number(arg);
+
+      return arg && Number.isFinite(pageId) ? { type: 'wmc', pageId } : null;
+    }
+    default: {
+      const r = ShowModalSchema.safeParse(type);
+
+      return r.success ? { type: r.data } : null;
+    }
+  }
+}
 
 /**
  * Sets a single tool's state, the only action for opening/focusing/closing one:
@@ -105,7 +190,9 @@ export const setTool = createAction<{ tool: Tool; mode: ToolMode }>('SET_TOOL');
 /** Replaces the whole open-tools set (URL restore; `[]` closes everything). */
 export const setTools = createAction<Tool[]>('SET_TOOLS');
 
-export const setActiveModal = createAction<Modal | null>('SET_ACTIVE_MODAL');
+export const setActiveModal = createAction<ActiveModal | Modal | null>(
+  'SET_ACTIVE_MODAL',
+);
 
 export { setLocation };
 

--- a/src/app/store/actions.ts
+++ b/src/app/store/actions.ts
@@ -33,7 +33,7 @@ export const ToolSchema = z.enum([
 
 export type Tool = z.infer<typeof ToolSchema>;
 
-const BASIC_MODALS = [
+const URL_MODAL_IDS = [
   'about',
   'account',
   'credits-purchase',
@@ -59,7 +59,7 @@ const BASIC_MODALS = [
   'tracking-watched',
 ] as const;
 
-export const ShowModalSchema = z.enum(BASIC_MODALS);
+export const UrlModalIdSchema = z.enum(URL_MODAL_IDS);
 
 /** Legacy modal ids (from old shared links) mapped to their current name. */
 const MODAL_RENAMES: Record<string, string> = {
@@ -77,15 +77,12 @@ const MODAL_RENAMES: Record<string, string> = {
   maps: 'my-maps',
 };
 
-export const ModalSchema = z.enum([
-  ...BASIC_MODALS,
-  'tips',
+export const ModalIdSchema = z.enum([
+  ...URL_MODAL_IDS,
   'current-drawing-properties',
 ]);
 
-export type Modal = z.infer<typeof ModalSchema>;
-
-export type ShowModal = z.infer<typeof ShowModalSchema>;
+export type ModalId = z.infer<typeof ModalIdSchema>;
 
 /**
  * The open modal/overlay. A discriminated union so a modal can carry an
@@ -93,15 +90,12 @@ export type ShowModal = z.infer<typeof ShowModalSchema>;
  * at a time. `null` means no modal.
  */
 export type ActiveModal =
-  | { type: Exclude<Modal, 'tracking-watched'> }
+  | { type: Exclude<ModalId, 'tracking-watched'> }
   | { type: 'tracking-watched'; token?: string }
   | { type: 'document'; key: Document }
   | { type: 'gallery-viewer'; id: number }
   | { type: 'wmc'; pageId: number }
   | { type: 'wiki'; key: string };
-
-/** Modal types that round-trip through the URL as `show=<type>[/<arg>]`. */
-const URL_SERIALIZABLE: ReadonlySet<string> = new Set(BASIC_MODALS);
 
 /**
  * Serializes the open modal to the packed `show=` value (`type` or `type/arg`),
@@ -127,7 +121,8 @@ export function encodeActiveModal(modal: ActiveModal | null): string | null {
     case 'wiki':
       return `wiki/${modal.key}`;
     default:
-      return URL_SERIALIZABLE.has(modal.type) ? modal.type : null;
+      // Only URL-serializable ids go in `show=`; current-drawing-properties doesn't.
+      return UrlModalIdSchema.safeParse(modal.type).success ? modal.type : null;
   }
 }
 
@@ -171,7 +166,7 @@ export function decodeShow(raw: string): ActiveModal | null {
     case 'wiki':
       return arg ? { type: 'wiki', key: arg } : null;
     default: {
-      const r = ShowModalSchema.safeParse(type);
+      const r = UrlModalIdSchema.safeParse(type);
 
       return r.success ? { type: r.data } : null;
     }
@@ -195,7 +190,19 @@ export const setTool = createAction<{ tool: Tool; mode: ToolMode }>('SET_TOOL');
 /** Replaces the whole open-tools set (URL restore; `[]` closes everything). */
 export const setTools = createAction<Tool[]>('SET_TOOLS');
 
-export const setActiveModal = createAction<ActiveModal | Modal | null>(
+/**
+ * Wraps an arg-less modal named by a `ModalId` into an `ActiveModal`, for the
+ * few call sites that open a modal chosen at runtime. The branch on
+ * `tracking-watched` is what lets the result narrow into the union — TypeScript
+ * can't distribute a `ModalId`-typed discriminant across the union members.
+ */
+export function modalOf(modalId: ModalId): ActiveModal {
+  return modalId === 'tracking-watched'
+    ? { type: 'tracking-watched' }
+    : { type: modalId };
+}
+
+export const setActiveModal = createAction<ActiveModal | null>(
   'SET_ACTIVE_MODAL',
 );
 

--- a/src/app/store/actions.ts
+++ b/src/app/store/actions.ts
@@ -97,7 +97,8 @@ export type ActiveModal =
   | { type: 'tracking-watched'; token?: string }
   | { type: 'document'; key: Document }
   | { type: 'gallery-viewer'; id: number }
-  | { type: 'wmc'; pageId: number };
+  | { type: 'wmc'; pageId: number }
+  | { type: 'wiki'; key: string };
 
 /** Modal types that round-trip through the URL as `show=<type>[/<arg>]`. */
 const URL_SERIALIZABLE: ReadonlySet<string> = new Set(BASIC_MODALS);
@@ -123,6 +124,8 @@ export function encodeActiveModal(modal: ActiveModal | null): string | null {
       return `gallery-viewer/${modal.id}`;
     case 'wmc':
       return `wmc/${modal.pageId}`;
+    case 'wiki':
+      return `wiki/${modal.key}`;
     default:
       return URL_SERIALIZABLE.has(modal.type) ? modal.type : null;
   }
@@ -165,6 +168,8 @@ export function decodeShow(raw: string): ActiveModal | null {
 
       return arg && Number.isFinite(pageId) ? { type: 'wmc', pageId } : null;
     }
+    case 'wiki':
+      return arg ? { type: 'wiki', key: arg } : null;
     default: {
       const r = ShowModalSchema.safeParse(type);
 

--- a/src/app/store/actions.ts
+++ b/src/app/store/actions.ts
@@ -4,10 +4,6 @@ import {
   setAnalyticCookiesAllowed,
 } from '@features/cookieConsent/model/actions.js';
 import {
-  type Document,
-  DocumentSchema,
-} from '@features/documents/model/actions.js';
-import {
   saveHomeLocation,
   setSelectingHomeLocation,
 } from '@features/homeLocation/model/actions.js';
@@ -18,6 +14,7 @@ import type { CustomLayerDef } from '@shared/mapDefinitions.js';
 import { OsmFeatureId } from '@shared/types/featureId.js';
 import z from 'zod';
 import type { DrawingStyle } from '@/features/drawing/model/reducers/drawingSettingsReducer.js';
+import type { ActiveModal } from './activeModal.js';
 
 export const ToolSchema = z.enum([
   'changesets',
@@ -32,146 +29,6 @@ export const ToolSchema = z.enum([
 ]);
 
 export type Tool = z.infer<typeof ToolSchema>;
-
-const URL_MODAL_IDS = [
-  'about',
-  'account',
-  'credits-purchase',
-  'custom-maps',
-  'drawing-properties',
-  'embed',
-  'file-import',
-  'gallery-filter',
-  'gallery-leaderboard',
-  'gallery-upload',
-  'legend',
-  'login',
-  'map-features-export',
-  'map-layers-config',
-  'map-preferences',
-  'map-to-document-export',
-  'my-maps',
-  'offline-map-export',
-  'offline-maps',
-  'premium',
-  'support-us',
-  'tracking-my',
-  'tracking-watched',
-] as const;
-
-export const UrlModalIdSchema = z.enum(URL_MODAL_IDS);
-
-/** Legacy modal ids (from old shared links) mapped to their current name. */
-const MODAL_RENAMES: Record<string, string> = {
-  'export-map': 'map-to-document-export',
-  'export-gpx': 'map-features-export',
-  'export-map-features': 'map-features-export',
-  'export-pdf': 'map-to-document-export',
-  'download-map': 'offline-map-export',
-  supportUs: 'support-us',
-  mapSettings: 'map-layers-config',
-  'map-settings': 'map-layers-config',
-  'remove-ads': 'premium',
-  'upload-track': 'file-import',
-  'buy-credits': 'credits-purchase',
-  maps: 'my-maps',
-};
-
-export const ModalIdSchema = z.enum([
-  ...URL_MODAL_IDS,
-  'current-drawing-properties',
-]);
-
-export type ModalId = z.infer<typeof ModalIdSchema>;
-
-/**
- * The open modal/overlay. A discriminated union so a modal can carry an
- * argument (e.g. the document key or watched-device token). At most one is open
- * at a time. `null` means no modal.
- */
-export type ActiveModal =
-  | { type: Exclude<ModalId, 'tracking-watched'> }
-  | { type: 'tracking-watched'; token?: string }
-  | { type: 'document'; key: Document }
-  | { type: 'gallery-viewer'; id: number }
-  | { type: 'wmc'; pageId: number }
-  | { type: 'wiki'; key: string };
-
-/**
- * Serializes the open modal to the packed `show=` value (`type` or `type/arg`),
- * or `null` when it has no URL representation. The literal `/` survives because
- * `serializeQuery` un-escapes `%2F`.
- */
-export function encodeActiveModal(modal: ActiveModal | null): string | null {
-  if (!modal) {
-    return null;
-  }
-
-  switch (modal.type) {
-    case 'tracking-watched':
-      return modal.token
-        ? `tracking-watched/${modal.token}`
-        : 'tracking-watched';
-    case 'document':
-      return `document/${modal.key}`;
-    case 'gallery-viewer':
-      return `gallery-viewer/${modal.id}`;
-    case 'wmc':
-      return `wmc/${modal.pageId}`;
-    case 'wiki':
-      return `wiki/${modal.key}`;
-    default:
-      // Only URL-serializable ids go in `show=`; current-drawing-properties doesn't.
-      return UrlModalIdSchema.safeParse(modal.type).success ? modal.type : null;
-  }
-}
-
-/**
- * Parses a packed `show=` value (`type` or `type/arg`) into an `ActiveModal`,
- * applying legacy name renames. Returns `null` when nothing valid is named.
- */
-export function decodeShow(raw: string): ActiveModal | null {
-  if (!raw) {
-    return null;
-  }
-
-  const slash = raw.indexOf('/');
-
-  const rawType = slash === -1 ? raw : raw.slice(0, slash);
-
-  const arg = slash === -1 ? undefined : raw.slice(slash + 1);
-
-  const type = MODAL_RENAMES[rawType] ?? rawType;
-
-  switch (type) {
-    case 'tracking-watched':
-      return arg
-        ? { type: 'tracking-watched', token: arg }
-        : { type: 'tracking-watched' };
-    case 'document': {
-      const r = DocumentSchema.safeParse(arg);
-
-      return r.success ? { type: 'document', key: r.data } : null;
-    }
-    case 'gallery-viewer': {
-      const id = Number(arg);
-
-      return arg && Number.isFinite(id) ? { type: 'gallery-viewer', id } : null;
-    }
-    case 'wmc': {
-      const pageId = Number(arg);
-
-      return arg && Number.isFinite(pageId) ? { type: 'wmc', pageId } : null;
-    }
-    case 'wiki':
-      return arg ? { type: 'wiki', key: arg } : null;
-    default: {
-      const r = UrlModalIdSchema.safeParse(type);
-
-      return r.success ? { type: r.data } : null;
-    }
-  }
-}
 
 /**
  * Sets a single tool's state, the only action for opening/focusing/closing one:
@@ -189,18 +46,6 @@ export const setTool = createAction<{ tool: Tool; mode: ToolMode }>('SET_TOOL');
 
 /** Replaces the whole open-tools set (URL restore; `[]` closes everything). */
 export const setTools = createAction<Tool[]>('SET_TOOLS');
-
-/**
- * Wraps an arg-less modal named by a `ModalId` into an `ActiveModal`, for the
- * few call sites that open a modal chosen at runtime. The branch on
- * `tracking-watched` is what lets the result narrow into the union — TypeScript
- * can't distribute a `ModalId`-typed discriminant across the union members.
- */
-export function modalOf(modalId: ModalId): ActiveModal {
-  return modalId === 'tracking-watched'
-    ? { type: 'tracking-watched' }
-    : { type: modalId };
-}
 
 export const setActiveModal = createAction<ActiveModal | null>(
   'SET_ACTIVE_MODAL',

--- a/src/app/store/activeModal.ts
+++ b/src/app/store/activeModal.ts
@@ -1,0 +1,157 @@
+import {
+  type Document,
+  DocumentSchema,
+} from '@features/documents/model/actions.js';
+import z from 'zod';
+
+const URL_MODAL_IDS = [
+  'about',
+  'account',
+  'credits-purchase',
+  'custom-maps',
+  'drawing-properties',
+  'embed',
+  'file-import',
+  'gallery-filter',
+  'gallery-leaderboard',
+  'gallery-upload',
+  'legend',
+  'login',
+  'map-features-export',
+  'map-layers-config',
+  'map-preferences',
+  'map-to-document-export',
+  'my-maps',
+  'offline-map-export',
+  'offline-maps',
+  'premium',
+  'support-us',
+  'tracking-my',
+  'tracking-watched',
+] as const;
+
+export const UrlModalIdSchema = z.enum(URL_MODAL_IDS);
+
+/** Legacy modal ids (from old shared links) mapped to their current name. */
+const MODAL_RENAMES: Record<string, string> = {
+  'export-map': 'map-to-document-export',
+  'export-gpx': 'map-features-export',
+  'export-map-features': 'map-features-export',
+  'export-pdf': 'map-to-document-export',
+  'download-map': 'offline-map-export',
+  supportUs: 'support-us',
+  mapSettings: 'map-layers-config',
+  'map-settings': 'map-layers-config',
+  'remove-ads': 'premium',
+  'upload-track': 'file-import',
+  'buy-credits': 'credits-purchase',
+  maps: 'my-maps',
+};
+
+export const ModalIdSchema = z.enum([
+  ...URL_MODAL_IDS,
+  'current-drawing-properties',
+]);
+
+export type ModalId = z.infer<typeof ModalIdSchema>;
+
+/**
+ * The open modal/overlay. A discriminated union so a modal can carry an
+ * argument (e.g. the document key or watched-device token). At most one is open
+ * at a time. `null` means no modal.
+ */
+export type ActiveModal =
+  | { type: Exclude<ModalId, 'tracking-watched'> }
+  | { type: 'tracking-watched'; token?: string }
+  | { type: 'document'; key: Document }
+  | { type: 'gallery-viewer'; id: number }
+  | { type: 'wmc'; pageId: number }
+  | { type: 'wiki'; key: string };
+
+/**
+ * Serializes the open modal to the packed `show=` value (`type` or `type/arg`),
+ * or `null` when it has no URL representation. The literal `/` survives because
+ * `serializeQuery` un-escapes `%2F`.
+ */
+export function encodeActiveModal(modal: ActiveModal | null): string | null {
+  if (!modal) {
+    return null;
+  }
+
+  switch (modal.type) {
+    case 'tracking-watched':
+      return modal.token
+        ? `tracking-watched/${modal.token}`
+        : 'tracking-watched';
+    case 'document':
+      return `document/${modal.key}`;
+    case 'gallery-viewer':
+      return `gallery-viewer/${modal.id}`;
+    case 'wmc':
+      return `wmc/${modal.pageId}`;
+    case 'wiki':
+      return `wiki/${modal.key}`;
+    default:
+      // Only URL-serializable ids go in `show=`; current-drawing-properties doesn't.
+      return UrlModalIdSchema.safeParse(modal.type).success ? modal.type : null;
+  }
+}
+
+/**
+ * Parses a packed `show=` value (`type` or `type/arg`) into an `ActiveModal`,
+ * applying legacy name renames. Returns `null` when nothing valid is named.
+ */
+export function decodeActiveModal(raw: string): ActiveModal | null {
+  if (!raw) {
+    return null;
+  }
+
+  const slash = raw.indexOf('/');
+
+  const rawType = slash === -1 ? raw : raw.slice(0, slash);
+
+  const arg = slash === -1 ? undefined : raw.slice(slash + 1);
+
+  const type = MODAL_RENAMES[rawType] ?? rawType;
+
+  switch (type) {
+    case 'tracking-watched':
+      return arg
+        ? { type: 'tracking-watched', token: arg }
+        : { type: 'tracking-watched' };
+    case 'document': {
+      const r = DocumentSchema.safeParse(arg);
+
+      return r.success ? { type: 'document', key: r.data } : null;
+    }
+    case 'gallery-viewer': {
+      const id = Number(arg);
+
+      return arg && Number.isFinite(id) ? { type: 'gallery-viewer', id } : null;
+    }
+    case 'wmc': {
+      const pageId = Number(arg);
+
+      return arg && Number.isFinite(pageId) ? { type: 'wmc', pageId } : null;
+    }
+    case 'wiki':
+      return arg ? { type: 'wiki', key: arg } : null;
+    default: {
+      const r = UrlModalIdSchema.safeParse(type);
+
+      return r.success ? { type: r.data } : null;
+    }
+  }
+}
+
+/**
+ * Wraps an arg-less modal named by a `ModalId` into an `ActiveModal`, for the
+ * few call sites that open a modal chosen at runtime. The branch on
+ * `tracking-watched` is what lets the result narrow into the union — TypeScript
+ * can't distribute a `ModalId`-typed discriminant across the union members.
+ */
+export function modalOf(modalId: ModalId): ActiveModal {
+  return modalId === 'tracking-watched'
+    ? { type: 'tracking-watched' }
+    : { type: modalId };
+}

--- a/src/app/store/reducer.ts
+++ b/src/app/store/reducer.ts
@@ -122,10 +122,7 @@ export const mainReducer = createReducer(mainInitialState, (builder) => {
       state.selection = null;
     })
     .addCase(setActiveModal, (state, action) => {
-      state.activeModal =
-        typeof action.payload === 'string'
-          ? ({ type: action.payload } as ActiveModal)
-          : action.payload;
+      state.activeModal = action.payload;
     })
     .addCase(documentShow, (state, action) => {
       state.activeModal = action.payload

--- a/src/app/store/reducer.ts
+++ b/src/app/store/reducer.ts
@@ -26,11 +26,11 @@ import {
   isMapClickTool,
 } from '@shared/toolDefinitions.js';
 import {
+  ActiveModal,
   clearMapFeatures,
   convertToDrawing,
   deleteFeature,
   hideInfoBar,
-  Modal,
   Selection,
   selectFeature,
   setActiveModal,
@@ -45,11 +45,10 @@ export interface MainState {
   tools: Tool[];
   /** The focused tool whose toolbar is highlighted; the click owner if it's a map-click tool. */
   activeTool: Tool | null;
-  activeModal: Modal | null;
+  activeModal: ActiveModal | null;
   errorTicketId: string | undefined;
   embedFeatures: string[];
   selection: Selection | null;
-  documentKey: string | null;
   hiddenInfoBars: Record<string, number>;
 }
 
@@ -60,7 +59,6 @@ export const mainInitialState: MainState = {
   errorTicketId: undefined,
   embedFeatures: [],
   selection: null,
-  documentKey: null,
   hiddenInfoBars: {},
 };
 
@@ -124,14 +122,15 @@ export const mainReducer = createReducer(mainInitialState, (builder) => {
       state.selection = null;
     })
     .addCase(setActiveModal, (state, action) => {
-      state.activeModal = action.payload;
+      state.activeModal =
+        typeof action.payload === 'string'
+          ? ({ type: action.payload } as ActiveModal)
+          : action.payload;
     })
     .addCase(documentShow, (state, action) => {
-      state.documentKey = action.payload;
-
-      if (action.payload) {
-        state.activeModal = null;
-      }
+      state.activeModal = action.payload
+        ? { type: 'document', key: action.payload }
+        : null;
     })
     .addCase(setErrorTicketId, (state, action) => {
       state.errorTicketId = action.payload;

--- a/src/app/store/reducer.ts
+++ b/src/app/store/reducer.ts
@@ -26,7 +26,6 @@ import {
   isMapClickTool,
 } from '@shared/toolDefinitions.js';
 import {
-  ActiveModal,
   clearMapFeatures,
   convertToDrawing,
   deleteFeature,
@@ -40,6 +39,7 @@ import {
   setTools,
   Tool,
 } from './actions.js';
+import type { ActiveModal } from './activeModal.js';
 
 export interface MainState {
   tools: Tool[];

--- a/src/app/url/locationChangeHandler.ts
+++ b/src/app/url/locationChangeHandler.ts
@@ -55,6 +55,7 @@ import {
   wikiLoadPreview,
   wikiSetPreview,
 } from '@features/wiki/model/actions.js';
+import { wikiPreviewKey } from '@features/wiki/model/wikiPreviewKey.js';
 import {
   wikimediaCommonsLoadPreview,
   wikimediaCommonsSetPreview,
@@ -682,8 +683,7 @@ export function handleLocationChange(store: MyStore): void {
       const w = getState().wiki;
 
       const current =
-        w.loading ??
-        (w.preview ? `${w.preview.lang}:${w.preview.langTitle}` : null);
+        w.loading ?? (w.preview ? wikiPreviewKey(w.preview) : null);
 
       if (current !== next.key) {
         dispatch(wikiLoadPreview(next.key));

--- a/src/app/url/locationChangeHandler.ts
+++ b/src/app/url/locationChangeHandler.ts
@@ -4,10 +4,6 @@ import {
   changesetsSetParams,
 } from '@features/changesets/model/actions.js';
 import {
-  DocumentSchema,
-  documentShow,
-} from '@features/documents/model/actions.js';
-import {
   drawingLineSetLines,
   Line,
   type LineCap,
@@ -74,8 +70,8 @@ import type { LatLon } from '@shared/types/common.js';
 import Color from 'color';
 import type { Dispatch } from 'redux';
 import {
-  ShowModalCompatSchema,
-  ShowModalSchema,
+  decodeShow,
+  encodeActiveModal,
   selectFeature,
   setActiveModal,
   setEmbedFeatures,
@@ -637,26 +633,26 @@ export function handleLocationChange(store: MyStore): void {
     );
   }
 
-  const activeModal = getState().main.activeModal;
+  {
+    // Unified modal/overlay param. Legacy `document=`/`tip=<key>` links fold
+    // into the packed `show=document/<key>` form.
+    const showRaw =
+      typeof query['show'] === 'string'
+        ? query['show']
+        : typeof query['document'] === 'string'
+          ? `document/${query['document']}`
+          : typeof query['tip'] === 'string'
+            ? `document/${query['tip']}`
+            : undefined;
 
-  const result = ShowModalCompatSchema.safeParse(query['show']);
+    const nextModal = showRaw === undefined ? null : decodeShow(showRaw);
 
-  if (result.success) {
-    if (result.data !== activeModal) {
-      dispatch(setActiveModal(result.data));
+    if (
+      encodeActiveModal(getState().main.activeModal) !==
+      encodeActiveModal(nextModal)
+    ) {
+      dispatch(setActiveModal(nextModal));
     }
-  } else if (ShowModalSchema.safeParse(activeModal).success) {
-    dispatch(setActiveModal(null));
-  }
-
-  const doc = DocumentSchema.safeParse(query['document'] ?? query['tip']);
-
-  if (doc.success) {
-    if (getState().main.documentKey !== doc.data) {
-      dispatch(documentShow(doc.data));
-    }
-  } else if (getState().main.documentKey) {
-    dispatch(documentShow(null));
   }
 
   const embed = query['embed'];

--- a/src/app/url/locationChangeHandler.ts
+++ b/src/app/url/locationChangeHandler.ts
@@ -634,8 +634,8 @@ export function handleLocationChange(store: MyStore): void {
   }
 
   {
-    // Unified modal/overlay param. Legacy `document=`/`tip=<key>` links fold
-    // into the packed `show=document/<key>` form.
+    // Unified modal/overlay param. Legacy `document=`/`tip=`/`image=`/`wmc=`
+    // links fold into the packed `show=type/arg` form.
     const showRaw =
       typeof query['show'] === 'string'
         ? query['show']
@@ -643,15 +643,45 @@ export function handleLocationChange(store: MyStore): void {
           ? `document/${query['document']}`
           : typeof query['tip'] === 'string'
             ? `document/${query['tip']}`
-            : undefined;
+            : typeof query['image'] === 'string'
+              ? `gallery-viewer/${query['image']}`
+              : typeof query['wmc'] === 'string'
+                ? `wmc/${query['wmc']}`
+                : undefined;
 
-    const nextModal = showRaw === undefined ? null : decodeShow(showRaw);
+    const next = showRaw === undefined ? null : decodeShow(showRaw);
+
+    // The gallery viewer and the Wikimedia Commons preview own their own slice
+    // state; everything else lives in main.activeModal.
+    if (next?.type === 'gallery-viewer') {
+      if (getState().gallery.activeImageId !== next.id) {
+        dispatch(galleryRequestImage(next.id));
+      }
+    } else if (getState().gallery.activeImageId) {
+      dispatch(galleryClear());
+    }
+
+    if (next?.type === 'wmc') {
+      const wmc = getState().wikimediaCommons;
+
+      if (wmc.preview?.pageId !== next.pageId && wmc.loading !== next.pageId) {
+        dispatch(wikimediaCommonsLoadPreview(next.pageId));
+      }
+    } else if (
+      getState().wikimediaCommons.preview ||
+      getState().wikimediaCommons.loading
+    ) {
+      dispatch(wikimediaCommonsSetPreview(null));
+    }
+
+    const mainNext =
+      next?.type === 'gallery-viewer' || next?.type === 'wmc' ? null : next;
 
     if (
       encodeActiveModal(getState().main.activeModal) !==
-      encodeActiveModal(nextModal)
+      encodeActiveModal(mainNext)
     ) {
-      dispatch(setActiveModal(nextModal));
+      dispatch(setActiveModal(mainNext));
     }
   }
 
@@ -934,35 +964,6 @@ function handleGallery(
     if (Object.keys(newFilter).length !== 0) {
       dispatch(gallerySetFilter({ ...filter, ...newFilter }));
     }
-  }
-
-  if (typeof query['image'] === 'string') {
-    const imageId = Number(query['image']);
-
-    if (getState().gallery.activeImageId !== imageId) {
-      dispatch(galleryRequestImage(imageId));
-    }
-  } else if (getState().gallery.activeImageId) {
-    dispatch(galleryClear());
-  }
-
-  if (typeof query['wmc'] === 'string') {
-    const pageId = Number(query['wmc']);
-
-    const wmcState = getState().wikimediaCommons;
-
-    if (
-      Number.isFinite(pageId) &&
-      wmcState.preview?.pageId !== pageId &&
-      wmcState.loading !== pageId
-    ) {
-      dispatch(wikimediaCommonsLoadPreview(pageId));
-    }
-  } else if (
-    getState().wikimediaCommons.preview ||
-    getState().wikimediaCommons.loading
-  ) {
-    dispatch(wikimediaCommonsSetPreview(null));
   }
 
   const cb = GalleryColorizeBySchema.safeParse(query['gallery-cb']);

--- a/src/app/url/locationChangeHandler.ts
+++ b/src/app/url/locationChangeHandler.ts
@@ -52,6 +52,10 @@ import {
   trackViewerGpxLoad,
 } from '@features/trackViewer/model/actions.js';
 import {
+  wikiLoadPreview,
+  wikiSetPreview,
+} from '@features/wiki/model/actions.js';
+import {
   wikimediaCommonsLoadPreview,
   wikimediaCommonsSetPreview,
 } from '@features/wikimediaCommons/model/actions.js';
@@ -674,8 +678,26 @@ export function handleLocationChange(store: MyStore): void {
       dispatch(wikimediaCommonsSetPreview(null));
     }
 
+    if (next?.type === 'wiki') {
+      const w = getState().wiki;
+
+      const current =
+        w.loading ??
+        (w.preview ? `${w.preview.lang}:${w.preview.langTitle}` : null);
+
+      if (current !== next.key) {
+        dispatch(wikiLoadPreview(next.key));
+      }
+    } else if (getState().wiki.preview || getState().wiki.loading) {
+      dispatch(wikiSetPreview(null));
+    }
+
     const mainNext =
-      next?.type === 'gallery-viewer' || next?.type === 'wmc' ? null : next;
+      next?.type === 'gallery-viewer' ||
+      next?.type === 'wmc' ||
+      next?.type === 'wiki'
+        ? null
+        : next;
 
     if (
       encodeActiveModal(getState().main.activeModal) !==

--- a/src/app/url/locationChangeHandler.ts
+++ b/src/app/url/locationChangeHandler.ts
@@ -75,8 +75,6 @@ import type { LatLon } from '@shared/types/common.js';
 import Color from 'color';
 import type { Dispatch } from 'redux';
 import {
-  decodeShow,
-  encodeActiveModal,
   selectFeature,
   setActiveModal,
   setEmbedFeatures,
@@ -84,6 +82,7 @@ import {
   Tool,
   ToolSchema,
 } from '../store/actions.js';
+import { decodeActiveModal, encodeActiveModal } from '../store/activeModal.js';
 import type { RootAction } from '../store/rootAction.js';
 import type { MyStore, RootState } from '../store/store.js';
 import { getMapStateDiffFromUrl, getMapStateFromUrl } from './urlMapUtils.js';
@@ -654,7 +653,7 @@ export function handleLocationChange(store: MyStore): void {
                 ? `wmc/${query['wmc']}`
                 : undefined;
 
-    const next = showRaw === undefined ? null : decodeShow(showRaw);
+    const next = showRaw === undefined ? null : decodeActiveModal(showRaw);
 
     // The gallery viewer and the Wikimedia Commons preview own their own slice
     // state; everything else lives in main.activeModal.

--- a/src/app/url/urlProcessor.ts
+++ b/src/app/url/urlProcessor.ts
@@ -4,7 +4,7 @@ import { integratedLayerDefMap } from '@shared/mapDefinitions.js';
 import { transportTypeDefs } from '@shared/transportTypeDefs.js';
 import type { LatLon } from '@shared/types/common.js';
 import { hash } from 'ohash';
-import { encodeActiveModal } from '../store/actions.js';
+import { encodeActiveModal } from '../store/activeModal.js';
 import type { Processor } from '../store/middleware/processorMiddleware.js';
 import { isUrlUpdatingEnabled } from './urlUpdating.js';
 

--- a/src/app/url/urlProcessor.ts
+++ b/src/app/url/urlProcessor.ts
@@ -3,7 +3,7 @@ import { integratedLayerDefMap } from '@shared/mapDefinitions.js';
 import { transportTypeDefs } from '@shared/transportTypeDefs.js';
 import type { LatLon } from '@shared/types/common.js';
 import { hash } from 'ohash';
-import { ShowModalSchema } from '../store/actions.js';
+import { encodeActiveModal } from '../store/actions.js';
 import type { Processor } from '../store/middleware/processorMiddleware.js';
 import { isUrlUpdatingEnabled } from './urlUpdating.js';
 
@@ -77,7 +77,6 @@ export const urlProcessor: Processor = {
       routePlanner.mode,
       routePlanner.transportType,
       routePlanner.roundtripParams,
-      main.documentKey,
       tracking.trackedDevices,
       trackViewer.colorizeTrackBy,
       trackViewer.gpxUrl,
@@ -369,15 +368,11 @@ export const urlProcessor: Processor = {
     }
 
     {
-      const result = ShowModalSchema.safeParse(main.activeModal);
+      const show = encodeActiveModal(main.activeModal);
 
-      if (result.success) {
-        queryParts.push(['show', result.data]);
+      if (show !== null) {
+        queryParts.push(['show', show]);
       }
-    }
-
-    if (main.documentKey !== null) {
-      queryParts.push(['document', main.documentKey]);
     }
 
     if (main.embedFeatures.length) {

--- a/src/app/url/urlProcessor.ts
+++ b/src/app/url/urlProcessor.ts
@@ -41,6 +41,7 @@ export const urlProcessor: Processor = {
       search,
       objects,
       wikimediaCommons,
+      wiki,
     } = getState();
 
     if (!isUrlUpdatingEnabled()) {
@@ -89,6 +90,8 @@ export const urlProcessor: Processor = {
       objects.active,
       wikimediaCommons.preview?.pageId,
       wikimediaCommons.loading,
+      wiki.preview,
+      wiki.loading,
     ];
 
     const restChanged =
@@ -362,6 +365,12 @@ export const urlProcessor: Processor = {
       const wmcPageId =
         wikimediaCommons.preview?.pageId ?? wikimediaCommons.loading;
 
+      const wikiKey =
+        wiki.loading ??
+        (wiki.preview
+          ? `${wiki.preview.lang}:${wiki.preview.langTitle}`
+          : null);
+
       const show =
         encodeActiveModal(main.activeModal) ??
         encodeActiveModal(
@@ -369,7 +378,9 @@ export const urlProcessor: Processor = {
             ? { type: 'gallery-viewer', id: gallery.activeImageId }
             : wmcPageId
               ? { type: 'wmc', pageId: wmcPageId }
-              : null,
+              : wikiKey
+                ? { type: 'wiki', key: wikiKey }
+                : null,
         );
 
       if (show !== null) {

--- a/src/app/url/urlProcessor.ts
+++ b/src/app/url/urlProcessor.ts
@@ -250,17 +250,6 @@ export const urlProcessor: Processor = {
       historyParts.push(['track-colorize-by', trackViewer.colorizeTrackBy]);
     }
 
-    if (gallery.activeImageId) {
-      queryParts.push(['image', gallery.activeImageId]);
-    }
-
-    const wmcPageId =
-      wikimediaCommons.preview?.pageId ?? wikimediaCommons.loading;
-
-    if (wmcPageId) {
-      queryParts.push(['wmc', wmcPageId]);
-    }
-
     if (changesets.days) {
       queryParts.push(['changesets-days', changesets.days]);
     }
@@ -368,7 +357,20 @@ export const urlProcessor: Processor = {
     }
 
     {
-      const show = encodeActiveModal(main.activeModal);
+      // The gallery viewer and the Wikimedia Commons preview keep their own
+      // slice state but serialize through the same packed `show=` param.
+      const wmcPageId =
+        wikimediaCommons.preview?.pageId ?? wikimediaCommons.loading;
+
+      const show =
+        encodeActiveModal(main.activeModal) ??
+        encodeActiveModal(
+          gallery.activeImageId
+            ? { type: 'gallery-viewer', id: gallery.activeImageId }
+            : wmcPageId
+              ? { type: 'wmc', pageId: wmcPageId }
+              : null,
+        );
 
       if (show !== null) {
         queryParts.push(['show', show]);

--- a/src/app/url/urlProcessor.ts
+++ b/src/app/url/urlProcessor.ts
@@ -1,4 +1,5 @@
 import { serializeShading } from '@features/parameterizedShading/model/Shading.js';
+import { wikiPreviewKey } from '@features/wiki/model/wikiPreviewKey.js';
 import { integratedLayerDefMap } from '@shared/mapDefinitions.js';
 import { transportTypeDefs } from '@shared/transportTypeDefs.js';
 import type { LatLon } from '@shared/types/common.js';
@@ -366,10 +367,7 @@ export const urlProcessor: Processor = {
         wikimediaCommons.preview?.pageId ?? wikimediaCommons.loading;
 
       const wikiKey =
-        wiki.loading ??
-        (wiki.preview
-          ? `${wiki.preview.lang}:${wiki.preview.langTitle}`
-          : null);
+        wiki.loading ?? (wiki.preview ? wikiPreviewKey(wiki.preview) : null);
 
       const show =
         encodeActiveModal(main.activeModal) ??

--- a/src/features/auth/model/processors/loginResponseHandler.ts
+++ b/src/features/auth/model/processors/loginResponseHandler.ts
@@ -78,6 +78,6 @@ export async function handleLoginResponse(
   if (clientData?.successAction) {
     dispatch(clientData.successAction);
   } else if (connect) {
-    dispatch(setActiveModal('account'));
+    dispatch(setActiveModal({ type: 'account' }));
   }
 }

--- a/src/features/credits/components/CredistAlert.tsx
+++ b/src/features/credits/components/CredistAlert.tsx
@@ -38,7 +38,9 @@ export function CreditsAlert({
           <Button
             type="button"
             className="m-n2 ms-2"
-            onClick={() => dispatch(setActiveModal('credits-purchase'))}
+            onClick={() =>
+              dispatch(setActiveModal({ type: 'credits-purchase' }))
+            }
           >
             <FaCoins /> {cm?.buyCredits}
           </Button>

--- a/src/features/credits/components/CreditsText.tsx
+++ b/src/features/credits/components/CreditsText.tsx
@@ -21,7 +21,7 @@ export function CreditsText({ credits, help }: Props) {
               onClick={(e) => {
                 e.preventDefault();
 
-                dispatch(setActiveModal('offline-map-export'));
+                dispatch(setActiveModal({ type: 'offline-map-export' }));
               }}
             >
               {re[2]}

--- a/src/features/documents/components/DocumentModal.tsx
+++ b/src/features/documents/components/DocumentModal.tsx
@@ -5,7 +5,7 @@ import { Button, Modal } from 'react-bootstrap';
 import { FaTimes } from 'react-icons/fa';
 import { useDispatch } from 'react-redux';
 import { getDocuments } from '@/documents/index.js';
-import { ModalSchema, setActiveModal } from '../../../app/store/actions.js';
+import { decodeShow, setActiveModal } from '../../../app/store/actions.js';
 import { DocumentSchema, documentShow } from '../model/actions.js';
 import { useDocumentsMessages } from '../translations/useDocumentsMessages.js';
 
@@ -92,10 +92,10 @@ function DocumentModal({ show }: Props): ReactElement | null {
             return;
           }
 
-          const show = ModalSchema.safeParse(sp.get('show'));
+          const modal = decodeShow(sp.get('show') ?? '');
 
-          if (show.success) {
-            dispatch(setActiveModal(show.data));
+          if (modal) {
+            dispatch(setActiveModal(modal));
           } else {
             const document = DocumentSchema.safeParse(sp.get('document'));
 

--- a/src/features/documents/components/DocumentModal.tsx
+++ b/src/features/documents/components/DocumentModal.tsx
@@ -19,7 +19,11 @@ function DocumentModal({ show }: Props): ReactElement | null {
 
   const dispatch = useDispatch();
 
-  const documentKey = useAppSelector((state) => state.main.documentKey);
+  const documentKey = useAppSelector((state) =>
+    state.main.activeModal?.type === 'document'
+      ? state.main.activeModal.key
+      : null,
+  );
 
   const language = useAppSelector((state) => state.l10n.language);
 

--- a/src/features/documents/components/DocumentModal.tsx
+++ b/src/features/documents/components/DocumentModal.tsx
@@ -1,3 +1,5 @@
+import { setActiveModal } from '@app/store/actions.js';
+import { decodeActiveModal } from '@app/store/activeModal.js';
 import { useMessages } from '@features/l10n/l10nInjector.js';
 import { useAppSelector } from '@shared/hooks/useAppSelector.js';
 import { type ReactElement, useEffect, useMemo, useState } from 'react';
@@ -5,8 +7,6 @@ import { Button, Modal } from 'react-bootstrap';
 import { FaTimes } from 'react-icons/fa';
 import { useDispatch } from 'react-redux';
 import { getDocuments } from '@/documents/index.js';
-import { setActiveModal } from '../../../app/store/actions.js';
-import { decodeActiveModal } from '../../../app/store/activeModal.js';
 import { DocumentSchema, documentShow } from '../model/actions.js';
 import { useDocumentsMessages } from '../translations/useDocumentsMessages.js';
 

--- a/src/features/documents/components/DocumentModal.tsx
+++ b/src/features/documents/components/DocumentModal.tsx
@@ -5,7 +5,8 @@ import { Button, Modal } from 'react-bootstrap';
 import { FaTimes } from 'react-icons/fa';
 import { useDispatch } from 'react-redux';
 import { getDocuments } from '@/documents/index.js';
-import { decodeShow, setActiveModal } from '../../../app/store/actions.js';
+import { setActiveModal } from '../../../app/store/actions.js';
+import { decodeActiveModal } from '../../../app/store/activeModal.js';
 import { DocumentSchema, documentShow } from '../model/actions.js';
 import { useDocumentsMessages } from '../translations/useDocumentsMessages.js';
 
@@ -92,7 +93,7 @@ function DocumentModal({ show }: Props): ReactElement | null {
             return;
           }
 
-          const modal = decodeShow(sp.get('show') ?? '');
+          const modal = decodeActiveModal(sp.get('show') ?? '');
 
           if (modal) {
             dispatch(setActiveModal(modal));

--- a/src/features/drawing/components/DrawingLineSelection.tsx
+++ b/src/features/drawing/components/DrawingLineSelection.tsx
@@ -189,7 +189,7 @@ export default function DrawingLineSelection(): ReactElement | null {
               className="ms-1"
               variant="secondary"
               onClick={() =>
-                dispatch(setActiveModal('current-drawing-properties'))
+                dispatch(setActiveModal({ type: 'current-drawing-properties' }))
               }
               {...props}
             >

--- a/src/features/drawing/components/DrawingMenu.tsx
+++ b/src/features/drawing/components/DrawingMenu.tsx
@@ -58,7 +58,9 @@ export default function DrawingMenu(): ReactElement | undefined {
               variant="secondary"
               type="button"
               className="ms-1"
-              onClick={() => dispatch(setActiveModal('drawing-properties'))}
+              onClick={() =>
+                dispatch(setActiveModal({ type: 'drawing-properties' }))
+              }
               {...props}
             >
               <FaPalette /> <span className={labelClassName}>{label}</span>

--- a/src/features/drawing/components/DrawingPointSelection.tsx
+++ b/src/features/drawing/components/DrawingPointSelection.tsx
@@ -92,7 +92,7 @@ export default function DrawingPointSelection(): ReactElement | null {
               className="ms-1"
               variant="secondary"
               onClick={() =>
-                dispatch(setActiveModal('current-drawing-properties'))
+                dispatch(setActiveModal({ type: 'current-drawing-properties' }))
               }
               {...props}
             >

--- a/src/features/gallery/components/GalleryMenu.tsx
+++ b/src/features/gallery/components/GalleryMenu.tsx
@@ -133,7 +133,9 @@ export default function GalleryMenu() {
                       type="button"
                       variant="secondary"
                       className="ms-1"
-                      onClick={() => dispatch(setActiveModal('gallery-upload'))}
+                      onClick={() =>
+                        dispatch(setActiveModal({ type: 'gallery-upload' }))
+                      }
                       {...props}
                     >
                       <FaUpload />{' '}
@@ -148,7 +150,9 @@ export default function GalleryMenu() {
                       type="button"
                       className="ms-1"
                       variant="secondary"
-                      onClick={() => dispatch(setActiveModal('gallery-filter'))}
+                      onClick={() =>
+                        dispatch(setActiveModal({ type: 'gallery-filter' }))
+                      }
                       active={filterIsActive}
                       {...props}
                     >
@@ -244,7 +248,9 @@ export default function GalleryMenu() {
                       className="ms-1"
                       variant="secondary"
                       onClick={() =>
-                        dispatch(setActiveModal('gallery-leaderboard'))
+                        dispatch(
+                          setActiveModal({ type: 'gallery-leaderboard' }),
+                        )
                       }
                       active={filterIsActive}
                       {...props}

--- a/src/features/gallery/components/GalleryModals.tsx
+++ b/src/features/gallery/components/GalleryModals.tsx
@@ -31,7 +31,7 @@ export function GalleryModals(): ReactElement {
 
   const showUploadModal = useAppSelector(
     (state) =>
-      state.main.activeModal === 'gallery-upload' &&
+      state.main.activeModal?.type === 'gallery-upload' &&
       state.gallery.pickingPositionForId === null,
   );
 

--- a/src/features/gallery/model/processors/galleryFetchUsersProcessor.ts
+++ b/src/features/gallery/model/processors/galleryFetchUsersProcessor.ts
@@ -8,7 +8,10 @@ export const galleryFetchUsersProcessor: Processor = {
   actionCreator: setActiveModal,
   // TODO error handling (resolve via loadGalleryMessages)
   async handle({ getState, dispatch, action }) {
-    if (setActiveModal.match(action) && action.payload !== 'gallery-filter') {
+    if (
+      setActiveModal.match(action) &&
+      action.payload?.type !== 'gallery-filter'
+    ) {
       return;
     }
 

--- a/src/features/gallery/model/processors/galleryUploadModalProcessor.ts
+++ b/src/features/gallery/model/processors/galleryUploadModalProcessor.ts
@@ -16,8 +16,8 @@ export const galleryUploadModalProcessor: Processor = {
       // don't load tags when canceling editing
       (galleryEditPicture.match(action) && !getState().gallery.editModel) ||
       (setActiveModal.match(action) &&
-        action.payload !== 'gallery-filter' &&
-        action.payload !== 'gallery-upload')
+        action.payload?.type !== 'gallery-filter' &&
+        action.payload?.type !== 'gallery-upload')
     ) {
       return;
     }

--- a/src/features/legend/model/legendProcessor.ts
+++ b/src/features/legend/model/legendProcessor.ts
@@ -4,7 +4,10 @@ import type { Processor } from '@app/store/middleware/processorMiddleware.js';
 export const legendProcessor: Processor<typeof setActiveModal> = {
   actionCreator: setActiveModal,
   transform: ({ getState, action }) => {
-    if (action.payload === 'legend' && getState().map.layers.includes('O')) {
+    if (
+      action.payload?.type === 'legend' &&
+      getState().map.layers.includes('O')
+    ) {
       window.open(
         'https://wiki.openstreetmap.org/wiki/Standard_tile_layer/Key',
       );

--- a/src/features/myMaps/components/MyMapsMenu.tsx
+++ b/src/features/myMaps/components/MyMapsMenu.tsx
@@ -43,7 +43,7 @@ export function MyMapsMenu(): ReactElement {
             {({ labelClassName, props }) => (
               <Button
                 variant="primary"
-                onClick={() => dispatch(setActiveModal('my-maps'))}
+                onClick={() => dispatch(setActiveModal({ type: 'my-maps' }))}
                 {...props}
               >
                 <FaRegMap />

--- a/src/features/myMaps/model/processors/mapsLoadListProcessor.ts
+++ b/src/features/myMaps/model/processors/mapsLoadListProcessor.ts
@@ -12,7 +12,7 @@ export const mapsLoadListProcessor: Processor = {
     try {
       if (
         getState().auth.validated &&
-        getState().main.activeModal === 'my-maps'
+        getState().main.activeModal?.type === 'my-maps'
       ) {
         const res = await httpRequest({
           getState,

--- a/src/features/premium/hooks/useBecomePremium.ts
+++ b/src/features/premium/hooks/useBecomePremium.ts
@@ -24,7 +24,7 @@ export function useBecomePremium() {
         dispatch(galleryClear());
       }
 
-      dispatch(setActiveModal('premium'));
+      dispatch(setActiveModal({ type: 'premium' }));
     },
     [dispatch, showGalleryViewer],
   );

--- a/src/features/purchases/model/processors/purchaseProcessor.ts
+++ b/src/features/purchases/model/processors/purchaseProcessor.ts
@@ -24,7 +24,7 @@ export const purchaseProcessor: Processor<typeof purchase> = {
     if (!user) {
       dispatch(purchaseOnLogin(action.payload));
 
-      dispatch(setActiveModal('login'));
+      dispatch(setActiveModal({ type: 'login' }));
 
       return;
     }

--- a/src/features/trackViewer/components/TrackViewerMenu.tsx
+++ b/src/features/trackViewer/components/TrackViewerMenu.tsx
@@ -128,7 +128,7 @@ export function TrackViewerMenu(): ReactElement {
                 className="ms-1"
                 variant="secondary"
                 onClick={() => {
-                  dispatch(setActiveModal('file-import'));
+                  dispatch(setActiveModal({ type: 'file-import' }));
                 }}
                 {...props}
               >

--- a/src/features/tracking/components/AccessToken.tsx
+++ b/src/features/tracking/components/AccessToken.tsx
@@ -32,10 +32,9 @@ import { useTrackingMessages } from '../translations/useTrackingMessages.js';
 
 type Props = {
   accessToken: AccessTokenType;
-  deviceName: string;
 };
 
-export function AccessToken({ accessToken, deviceName }: Props): ReactElement {
+export function AccessToken({ accessToken }: Props): ReactElement {
   const m = useMessages();
 
   const tm = useTrackingMessages();
@@ -79,15 +78,10 @@ export function AccessToken({ accessToken, deviceName }: Props): ReactElement {
   }, [accessToken.token, dispatch]);
 
   const handleView = useCallback(() => {
-    dispatch(setActiveModal('tracking-watched'));
-
     dispatch(
-      trackingActions.modifyTrackedDevice({
-        token: accessToken.token,
-        label: deviceName,
-      }),
+      setActiveModal({ type: 'tracking-watched', token: accessToken.token }),
     );
-  }, [accessToken.token, deviceName, dispatch]);
+  }, [accessToken.token, dispatch]);
 
   const meta: { label: string; value: ReactNode }[] = [];
 

--- a/src/features/tracking/components/AccessTokens.tsx
+++ b/src/features/tracking/components/AccessTokens.tsx
@@ -44,11 +44,7 @@ export function AccessTokens(): ReactElement {
         {accessTokens.length > 0 && (
           <ListGroup>
             {accessTokens.map((accessToken) => (
-              <AccessToken
-                key={accessToken.id}
-                accessToken={accessToken}
-                deviceName={deviceName}
-              />
+              <AccessToken key={accessToken.id} accessToken={accessToken} />
             ))}
           </ListGroup>
         )}

--- a/src/features/tracking/components/TrackedDevice.tsx
+++ b/src/features/tracking/components/TrackedDevice.tsx
@@ -1,3 +1,4 @@
+import { setActiveModal } from '@app/store/actions.js';
 import { useMessages } from '@features/l10n/l10nInjector.js';
 import { LongPressTooltip } from '@shared/components/LongPressTooltip.js';
 import { useDateTimeFormat } from '@shared/hooks/useDateTimeFormat.js';
@@ -37,8 +38,8 @@ export function TrackedDevice({ device }: Props): ReactElement {
   const nf = useNumberFormat();
 
   const handleModify = useCallback(() => {
-    dispatch(trackingActions.modifyTrackedDevice(device));
-  }, [device, dispatch]);
+    dispatch(setActiveModal({ type: 'tracking-watched', token: device.token }));
+  }, [device.token, dispatch]);
 
   const handleDelete = useCallback(() => {
     dispatch(trackingActions.deleteTrackedDevice(device.token));

--- a/src/features/tracking/components/TrackedDeviceForm.tsx
+++ b/src/features/tracking/components/TrackedDeviceForm.tsx
@@ -1,4 +1,4 @@
-import { selectFeature } from '@app/store/actions.js';
+import { selectFeature, setActiveModal } from '@app/store/actions.js';
 import { useMessages } from '@features/l10n/l10nInjector.js';
 import { DateTime } from '@shared/components/DateTime.js';
 import { toDatetimeLocal } from '@shared/dateUtils.js';
@@ -20,28 +20,31 @@ export function TrackedDeviceForm(): ReactElement {
 
   const dispatch = useDispatch();
 
-  const { device, forceNew } = useAppSelector((state) => {
+  const { device, forceNew, previousToken } = useAppSelector((state) => {
+    const am = state.main.activeModal;
+
+    const token = am?.type === 'tracking-watched' ? am.token : undefined;
+
     let device: TrackedDevice | undefined;
 
     let forceNew = false;
 
-    const modified = state.tracking.modifiedTrackedDevice;
-
-    if (modified != null) {
-      device = state.tracking.trackedDevices.find(
-        (d) => d.token === modified.token,
-      );
+    if (token) {
+      device = state.tracking.trackedDevices.find((d) => d.token === token);
 
       if (!device) {
-        device = modified;
+        device = { token } as TrackedDevice;
 
         forceNew = true;
       }
+    } else {
+      forceNew = true;
     }
 
     return {
       device,
       forceNew,
+      previousToken: forceNew ? null : (device?.token ?? null),
     };
   }, shallowEqual);
 
@@ -93,21 +96,26 @@ export function TrackedDeviceForm(): ReactElement {
 
     dispatch(
       trackingActions.saveTrackedDevice({
-        token: did,
-        label: label.trim() || null,
-        color: color === '#7239a8' ? null : color.trim() || null,
-        fromTime: fromTime === '' ? null : new Date(fromTime),
-        maxAge: maxAge === '' ? null : Number.parseInt(maxAge, 10) * 60,
-        maxCount: maxCount === '' ? null : Number.parseInt(maxCount, 10),
-        width: width === '' ? null : Number.parseInt(width, 10),
-        splitDistance:
-          splitDistance === '' ? null : Number.parseInt(splitDistance, 10),
-        splitDuration:
-          splitDuration === '' ? null : Number.parseInt(splitDuration, 10),
+        device: {
+          token: did,
+          label: label.trim() || null,
+          color: color === '#7239a8' ? null : color.trim() || null,
+          fromTime: fromTime === '' ? null : new Date(fromTime),
+          maxAge: maxAge === '' ? null : Number.parseInt(maxAge, 10) * 60,
+          maxCount: maxCount === '' ? null : Number.parseInt(maxCount, 10),
+          width: width === '' ? null : Number.parseInt(width, 10),
+          splitDistance:
+            splitDistance === '' ? null : Number.parseInt(splitDistance, 10),
+          splitDuration:
+            splitDuration === '' ? null : Number.parseInt(splitDuration, 10),
+        },
+        previousToken,
       }),
     );
 
     dispatch(selectFeature({ type: 'tracking', id: did }));
+
+    dispatch(setActiveModal({ type: 'tracking-watched' }));
   };
 
   return (
@@ -251,7 +259,7 @@ export function TrackedDeviceForm(): ReactElement {
           variant="dark"
           type="button"
           onClick={() => {
-            dispatch(trackingActions.modifyTrackedDevice(undefined));
+            dispatch(setActiveModal({ type: 'tracking-watched' }));
           }}
         >
           <FaTimes /> {m?.general.cancel} <kbd>Esc</kbd>

--- a/src/features/tracking/components/TrackedDevices.tsx
+++ b/src/features/tracking/components/TrackedDevices.tsx
@@ -5,7 +5,6 @@ import type { ReactElement } from 'react';
 import { Alert, Button, ListGroup, Modal } from 'react-bootstrap';
 import { FaEye, FaPlus, FaTimes } from 'react-icons/fa';
 import { useDispatch } from 'react-redux';
-import { trackingActions } from '../model/actions.js';
 import { useTrackingMessages } from '../translations/useTrackingMessages.js';
 import { TrackedDevice } from './TrackedDevice.js';
 
@@ -44,7 +43,7 @@ export function TrackedDevices(): ReactElement {
         <Button
           type="button"
           onClick={() => {
-            dispatch(trackingActions.modifyTrackedDevice(null));
+            dispatch(setActiveModal({ type: 'tracking-watched', token: '' }));
           }}
         >
           <FaPlus /> {m?.general.add}

--- a/src/features/tracking/components/TrackingMenu.tsx
+++ b/src/features/tracking/components/TrackingMenu.tsx
@@ -92,7 +92,9 @@ export function TrackingMenu(): ReactElement {
           <Button
             className="ms-1"
             variant="secondary"
-            onClick={() => dispatch(setActiveModal('tracking-watched'))}
+            onClick={() =>
+              dispatch(setActiveModal({ type: 'tracking-watched' }))
+            }
             {...props}
           >
             <FaRegEye />
@@ -106,7 +108,7 @@ export function TrackingMenu(): ReactElement {
           <Button
             className="ms-1"
             variant="secondary"
-            onClick={() => dispatch(setActiveModal('tracking-my'))}
+            onClick={() => dispatch(setActiveModal({ type: 'tracking-my' }))}
             {...props}
           >
             <FaMobileAlt />

--- a/src/features/tracking/components/TrackingModal.tsx
+++ b/src/features/tracking/components/TrackingModal.tsx
@@ -24,22 +24,26 @@ type Props = { show: boolean };
 
 export default function TrackingModal({ show }: Props): ReactElement {
   const isMy = useAppSelector(
-    (state) => state.main.activeModal === 'tracking-my',
+    (state) => state.main.activeModal?.type === 'tracking-my',
   );
 
-  const view = useAppSelector((state) =>
-    state.main.activeModal === 'tracking-my'
-      ? state.tracking.modifiedDeviceId !== undefined
+  const view = useAppSelector((state) => {
+    const am = state.main.activeModal;
+
+    if (am?.type === 'tracking-my') {
+      return state.tracking.modifiedDeviceId !== undefined
         ? 'deviceForm'
         : state.tracking.accessTokensDeviceId
           ? state.tracking.modifiedAccessTokenId !== undefined
             ? 'accessTokenForm'
             : 'accessTokens'
-          : 'devices'
-      : state.tracking.modifiedTrackedDevice !== undefined
-        ? 'trackedDeviceForm'
-        : 'trackedDevices',
-  );
+          : 'devices';
+    }
+
+    return am?.type === 'tracking-watched' && am.token !== undefined
+      ? 'trackedDeviceForm'
+      : 'trackedDevices';
+  });
 
   const tm = useTrackingMessages();
 

--- a/src/features/tracking/components/TrackingSelection.tsx
+++ b/src/features/tracking/components/TrackingSelection.tsx
@@ -6,6 +6,7 @@ import { FaBullseye, FaEye } from 'react-icons/fa';
 import { FaPencil } from 'react-icons/fa6';
 import { useDispatch } from 'react-redux';
 import { setActiveModal, setTool } from '@/app/store/actions.js';
+import { trackingActiveTrackIdSelector } from '@/app/store/selectors.js';
 import { LongPressTooltip } from '@/shared/components/LongPressTooltip.js';
 import { useAppSelector } from '@/shared/hooks/useAppSelector.js';
 
@@ -15,6 +16,8 @@ export function TrackingSelection(): ReactElement {
   const trackingOpen = useAppSelector((state) =>
     state.main.tools.includes('tracking'),
   );
+
+  const selectedToken = useAppSelector(trackingActiveTrackIdSelector);
 
   const dispatch = useDispatch();
 
@@ -49,7 +52,18 @@ export function TrackingSelection(): ReactElement {
             {...props}
             className="ms-1"
             variant="secondary"
-            onClick={() => dispatch(setActiveModal('tracking-watched'))} // TODO show active device
+            onClick={() =>
+              dispatch(
+                setActiveModal(
+                  selectedToken == null
+                    ? { type: 'tracking-watched' }
+                    : {
+                        type: 'tracking-watched',
+                        token: String(selectedToken),
+                      },
+                ),
+              )
+            }
           >
             <FaPencil />
           </Button>

--- a/src/features/tracking/model/actions.ts
+++ b/src/features/tracking/model/actions.ts
@@ -13,15 +13,13 @@ export const trackingActions = {
     'TRACKING_SET_TRACKED_DEVICES',
   ),
 
-  modifyTrackedDevice: createAction<TrackedDevice | null | undefined>(
-    'TRACKING_MODIFY_TRACKED_DEVICE',
-  ),
-
   deleteTrackedDevice: createAction<string>('TRACKING_DELETE_TRACKED_DEVICE'),
 
-  saveTrackedDevice: createAction<TrackedDevice>(
-    'TRACKING_SAVE_TRACKED_DEVICE',
-  ),
+  saveTrackedDevice: createAction<{
+    device: TrackedDevice;
+    /** Token of the edited device (so a renamed token replaces the old entry); null when creating. */
+    previousToken: string | null;
+  }>('TRACKING_SAVE_TRACKED_DEVICE'),
 
   setDevices: createAction<Device[]>('TRACKING_SET_DEVICES'),
 

--- a/src/features/tracking/model/reducer.test.ts
+++ b/src/features/tracking/model/reducer.test.ts
@@ -31,7 +31,6 @@ const withTracks = (tracks: Track[]) => ({
   accessTokensDeviceId: undefined,
   modifiedDeviceId: undefined,
   modifiedAccessTokenId: undefined,
-  modifiedTrackedDevice: undefined,
   trackedDevices: [],
   tracks,
   showLine: true,
@@ -40,33 +39,54 @@ const withTracks = (tracks: Track[]) => ({
 });
 
 describe('trackingReducer — tracked devices', () => {
-  it('saveTrackedDevice replaces the one being edited and clears the editor', () => {
+  it('saveTrackedDevice replaces the edited device, re-appending it', () => {
     const state = {
       ...withTracks([]),
       trackedDevices: [td('a', { label: 'old' }), td('b')],
-      modifiedTrackedDevice: td('a'),
     };
 
     const next = trackingReducer(
       state,
-      trackingActions.saveTrackedDevice(td('a', { label: 'new' })),
+      trackingActions.saveTrackedDevice({
+        device: td('a', { label: 'new' }),
+        previousToken: 'a',
+      }),
     );
 
     // 'a' is removed then re-appended at the end with the new label.
     expect(next.trackedDevices.map((d) => d.token)).toEqual(['b', 'a']);
     expect(next.trackedDevices.at(-1)?.label).toBe('new');
-    expect(next.modifiedTrackedDevice).toBeUndefined();
   });
 
-  it('saveTrackedDevice with no editor target just appends', () => {
+  it('saveTrackedDevice with no previous token just appends', () => {
     const state = { ...withTracks([]), trackedDevices: [td('a')] };
 
     const next = trackingReducer(
       state,
-      trackingActions.saveTrackedDevice(td('b')),
+      trackingActions.saveTrackedDevice({
+        device: td('b'),
+        previousToken: null,
+      }),
     );
 
     expect(next.trackedDevices.map((d) => d.token)).toEqual(['a', 'b']);
+  });
+
+  it('saveTrackedDevice with a renamed token drops the old entry', () => {
+    const state = {
+      ...withTracks([]),
+      trackedDevices: [td('a'), td('b')],
+    };
+
+    const next = trackingReducer(
+      state,
+      trackingActions.saveTrackedDevice({
+        device: td('c'),
+        previousToken: 'a',
+      }),
+    );
+
+    expect(next.trackedDevices.map((d) => d.token)).toEqual(['b', 'c']);
   });
 
   it('deleteTrackedDevice removes by token', () => {

--- a/src/features/tracking/model/reducer.ts
+++ b/src/features/tracking/model/reducer.ts
@@ -27,7 +27,6 @@ export interface TrackingState {
   accessTokensDeviceId: number | undefined;
   modifiedDeviceId: number | null | undefined;
   modifiedAccessTokenId: number | null | undefined;
-  modifiedTrackedDevice: TrackedDevice | null | undefined;
   trackedDevices: TrackedDevice[];
   tracks: Track[];
   showLine: boolean;
@@ -41,7 +40,6 @@ export const trackingInitialState: TrackingState = {
   accessTokensDeviceId: undefined,
   modifiedDeviceId: undefined,
   modifiedAccessTokenId: undefined,
-  modifiedTrackedDevice: undefined,
   trackedDevices: [],
   tracks: [],
   showLine: true,
@@ -65,7 +63,6 @@ export const trackingReducer = createReducer(trackingInitialState, (builder) =>
       accessTokensDeviceId: undefined,
       modifiedDeviceId: undefined,
       modifiedAccessTokenId: undefined,
-      modifiedTrackedDevice: undefined,
     }))
     .addCase(trackingActions.setDevices, (state, { payload }) => ({
       ...state,
@@ -92,20 +89,18 @@ export const trackingReducer = createReducer(trackingInitialState, (builder) =>
       ...state,
       trackedDevices: payload,
     }))
-    .addCase(trackingActions.modifyTrackedDevice, (state, { payload }) => ({
-      ...state,
-      modifiedTrackedDevice: payload,
-    }))
-    .addCase(trackingActions.saveTrackedDevice, (state, { payload }) => ({
-      ...state,
-      trackedDevices: [
-        ...state.trackedDevices.filter(
-          (d) => d.token !== state.modifiedTrackedDevice?.token,
-        ),
-        payload,
-      ],
-      modifiedTrackedDevice: undefined,
-    }))
+    .addCase(
+      trackingActions.saveTrackedDevice,
+      (state, { payload: { device, previousToken } }) => ({
+        ...state,
+        trackedDevices: [
+          ...state.trackedDevices.filter(
+            (d) => d.token !== previousToken && d.token !== device.token,
+          ),
+          device,
+        ],
+      }),
+    )
     .addCase(trackingActions.deleteTrackedDevice, (state, { payload }) => ({
       ...state,
       trackedDevices: state.trackedDevices.filter((d) => d.token !== payload),

--- a/src/features/wiki/model/wikiPreviewKey.ts
+++ b/src/features/wiki/model/wikiPreviewKey.ts
@@ -1,0 +1,9 @@
+import type { WikiPreview } from './actions.js';
+
+/**
+ * The `lang:title` key identifying a loaded preview — matches the
+ * `wikiLoadPreview` argument and the `show=wiki/<key>` URL form.
+ */
+export function wikiPreviewKey(preview: WikiPreview): string {
+  return `${preview.lang}:${preview.langTitle}`;
+}

--- a/src/processors/setActiveModalProcessor.ts
+++ b/src/processors/setActiveModalProcessor.ts
@@ -8,15 +8,20 @@ export const setActiveModalTransformer: Processor<typeof setActiveModal> = {
   transform: ({ getState, action }) => {
     const anonymous = !getState().auth.user;
 
+    const type =
+      typeof action.payload === 'string'
+        ? action.payload
+        : action.payload?.type;
+
     const blocked =
-      action.payload &&
+      type &&
       [
         'my-maps',
         'gallery-upload',
         'account',
         'tracking-my',
         'offline-map-export',
-      ].includes(action.payload) &&
+      ].includes(type) &&
       anonymous;
 
     if (blocked) {
@@ -28,8 +33,8 @@ export const setActiveModalTransformer: Processor<typeof setActiveModal> = {
     }
 
     // track every modal that actually opens (payload null closes a modal)
-    if (action.payload) {
-      window._paq.push(['trackEvent', 'Modal', 'open', action.payload]);
+    if (type) {
+      window._paq.push(['trackEvent', 'Modal', 'open', type]);
     }
 
     return action;

--- a/src/processors/setActiveModalProcessor.ts
+++ b/src/processors/setActiveModalProcessor.ts
@@ -8,10 +8,7 @@ export const setActiveModalTransformer: Processor<typeof setActiveModal> = {
   transform: ({ getState, action }) => {
     const anonymous = !getState().auth.user;
 
-    const type =
-      typeof action.payload === 'string'
-        ? action.payload
-        : action.payload?.type;
+    const type = action.payload?.type;
 
     const blocked =
       type &&

--- a/src/shared/components/ShowModalLink.tsx
+++ b/src/shared/components/ShowModalLink.tsx
@@ -1,8 +1,8 @@
+import { setActiveModal } from '@app/store/actions.js';
+import { ModalId, modalOf } from '@app/store/activeModal.js';
 import { MouseEvent, ReactNode, useCallback } from 'react';
 import { Anchor } from 'react-bootstrap';
 import { useDispatch } from 'react-redux';
-import { setActiveModal } from '../../app/store/actions.js';
-import { ModalId, modalOf } from '../../app/store/activeModal.js';
 
 type Props = {
   modal: ModalId;

--- a/src/shared/components/ShowModalLink.tsx
+++ b/src/shared/components/ShowModalLink.tsx
@@ -1,7 +1,8 @@
 import { MouseEvent, ReactNode, useCallback } from 'react';
 import { Anchor } from 'react-bootstrap';
 import { useDispatch } from 'react-redux';
-import { ModalId, modalOf, setActiveModal } from '../../app/store/actions.js';
+import { setActiveModal } from '../../app/store/actions.js';
+import { ModalId, modalOf } from '../../app/store/activeModal.js';
 
 type Props = {
   modal: ModalId;

--- a/src/shared/components/ShowModalLink.tsx
+++ b/src/shared/components/ShowModalLink.tsx
@@ -1,10 +1,10 @@
 import { MouseEvent, ReactNode, useCallback } from 'react';
 import { Anchor } from 'react-bootstrap';
 import { useDispatch } from 'react-redux';
-import { Modal, setActiveModal } from '../../app/store/actions.js';
+import { ModalId, modalOf, setActiveModal } from '../../app/store/actions.js';
 
 type Props = {
-  modal: Modal;
+  modal: ModalId;
   children: ReactNode;
 };
 
@@ -15,7 +15,7 @@ export function ShowModalLink({ modal, children }: Props) {
     (e: MouseEvent) => {
       e.preventDefault();
 
-      dispatch(setActiveModal(modal));
+      dispatch(setActiveModal(modalOf(modal)));
     },
     [dispatch, modal],
   );

--- a/src/shared/hooks/useMenuHandler.ts
+++ b/src/shared/hooks/useMenuHandler.ts
@@ -1,7 +1,8 @@
 import {
   clearMapFeatures,
   ExternalTarget,
-  Modal,
+  ModalId,
+  modalOf,
   openInExternalApp,
   saveSettings,
   setActiveModal,
@@ -33,12 +34,12 @@ export type EventKey =
   | `tool-${Tool}`
   | `lang-${Language | ''}`
   | `open-${ExternalTarget}`
-  | `modal-${Modal}`;
+  | `modal-${ModalId}`;
 
-export function modalMenuItemProps(modal: Modal) {
+export function modalMenuItemProps(modalId: ModalId) {
   return {
-    eventKey: `modal-${modal}`,
-    href: `#show=${modal}`,
+    eventKey: `modal-${modalId}`,
+    href: `#show=${modalId}`,
   };
 }
 
@@ -139,7 +140,7 @@ export function useMenuHandler({
       const modal = afterPrefix(key, 'modal-');
 
       if (modal !== undefined) {
-        dispatch(setActiveModal(modal));
+        dispatch(setActiveModal(modalOf(modal)));
 
         setShow(false);
 

--- a/src/shared/hooks/useMenuHandler.ts
+++ b/src/shared/hooks/useMenuHandler.ts
@@ -1,8 +1,6 @@
 import {
   clearMapFeatures,
   ExternalTarget,
-  ModalId,
-  modalOf,
   openInExternalApp,
   saveSettings,
   setActiveModal,
@@ -11,6 +9,7 @@ import {
   Tool,
   ToolSchema,
 } from '@app/store/actions.js';
+import { ModalId, modalOf } from '@app/store/activeModal.js';
 import { Document, documentShow } from '@features/documents/model/actions.js';
 import { l10nSetChosenLanguage } from '@features/l10n/model/actions.js';
 import { Submenu } from '@features/mainMenu/components/submenu.js';

--- a/src/static/llms.txt
+++ b/src/static/llms.txt
@@ -93,13 +93,13 @@ Toggles the photos toolbar and the community-photos map layer. Photos appear as 
 
 **Upload modal:** drag-and-drop or pick photos; per photo set name, description, capture date/time, location (with "Set the location" on the map), azimuth (shooting direction), tags, and an optional "make available only to premium users" flag. Shows the gallery rules (max 10 MB, landscapes/documentation only, own photos only, published under CC BY-SA 4.0, etc.).
 
-**Photo viewer:** shows the full image with CC BY-SA 4.0 attribution, uploader, capture date and rating; users can comment, rate, modify (own photos), delete, show on the map, open fullscreen, or open in an external app. Photos can be navigated sequentially (e.g. "1 / 51").
+**Photo viewer:** shows the full image with CC BY-SA 4.0 attribution, uploader, capture date and rating; users can comment, rate, modify (own photos), delete, show on the map, open fullscreen, or open in an external app. Photos can be navigated sequentially (e.g. "1 / 51"). URL path (open photo): `/#show=gallery-viewer/<id>` (legacy `/#image=<id>` still works).
 
 ### My maps
 
 - Access: Main menu > My maps
 - Keyboard shortcut: <kbd>g</kbd> <kbd>m</kbd>
-- URL path: `/#show=maps`
+- URL path: `/#show=my-maps` (legacy `/#show=maps` still works)
 
 Opens the user-saved maps manager in a modal. Each saved map stores the current state: active map layers, drawing, planned route, watched live-tracked devices, and GPX track.
 
@@ -203,7 +203,7 @@ The marker icon can be globally changed (pin/ring/square).
 - Keyboard shortcut: <kbd>g</kbd> <kbd>g</kbd>
 - URL path: `/#tools=import-file` (legacy `/#tool=import-file` and the old `track-viewer` alias still work)
 
-Toggles the file import toolbar. **Upload** opens the file import modal (URL path: `/#show=upload-track`), which accepts GPX and GeoJSON files. Once a track is loaded, the toolbar offers:
+Toggles the file import toolbar. **Upload** opens the file import modal (URL path: `/#show=file-import`; legacy `/#show=upload-track` still works), which accepts GPX and GeoJSON files. Once a track is loaded, the toolbar offers:
 
 - **Elevation profile** — chart of elevation along the track (with total climb/descent)
 - **Colorize by** (dropdown) — Inactive, Elevation, Steepness, Speed, Heart rate, Cadence, Power, Temperature, Time, Heading (entries with no data in the track are disabled)
@@ -573,6 +573,8 @@ Notes:
 ##### Internal layer codes
 
 The id values above are used in deep links via the `layers=` URL param: one base-layer code, optionally followed by `~` and the concatenated overlay codes (e.g. `layers=X~I` = Outdoor base + Photos overlay). They are **advisory** for interpreting links and do **not** grant permission to scrape tiles or data; respect each layer's attribution and license.
+
+Clicking a marker on the Wikipedia or Wikimedia Commons overlay opens a preview modal, addressable via the unified `show=` param: `/#show=wiki/<lang>:<title>` for a Wikipedia article and `/#show=wmc/<pageId>` for a Wikimedia Commons photo (legacy `/#wmc=<pageId>` still works).
 
 ## Links
 

--- a/src/static/llms.txt
+++ b/src/static/llms.txt
@@ -360,7 +360,7 @@ The target can be a downloaded file, Google Drive, Dropbox, or Garmin Connect. E
 ### Maps for GPS devices
 
 - Access: Main menu > Maps for GPS devices
-- URL path: `/#document=exports`
+- URL path: `/#show=document/exports` (legacy `/#document=exports` still works)
 
 Opens a modal with instructions to get various maps for GPS devices:
 


### PR DESCRIPTION
## Summary

Unifies all modal/overlay open-state behind one mechanism:

- `state.main.activeModal` is now a `Selection`-like discriminated union (`ActiveModal | null`) that can carry an argument, instead of a bare string.
- Every modal/overlay serializes through **one** packed URL param `show=type/arg` (`encodeActiveModal`/`decodeShow` in `app/store/actions.ts`), replacing the old mix of `show=` / `document=` / `image=` / `wmc=`. Old links keep working as legacy read-aliases.
- The tracking-selection pencil now opens the **edit form of the selected watched device** (the original ask), driven by `activeModal.token` (`show=tracking-watched/<token>`).

## What's covered

- **Document** overlay folded into `activeModal` (was `main.documentKey`).
- **Gallery viewer**, **Wikimedia Commons** preview, and **Wikipedia** preview now serialize through `show=` (`show=gallery-viewer/<id>`, `show=wmc/<pageId>`, `show=wiki/<lang>:<title>`). Their slice state is unchanged — only the URL layer was unified (the deeper state-fold is logged as optional in `TODO.md`).
- **Bug fix:** the wmc/wiki preview modals didn't suspend global keyboard shortcuts.
- **Bug fix (regression caught in review):** `setActiveModal` accepts only `ActiveModal | null` now — the earlier string-or-object duality let three `setActiveModal` listeners (`galleryFetchUsers`, `galleryUploadModal`, `legend`) compare the payload to a string and silently break when a modal was opened via URL. They now read `action.payload?.type`.

## Naming

`Modal` → `ModalId`, `ShowModalSchema` → `UrlModalIdSchema`, `BASIC_MODALS` → `URL_MODAL_IDS`; dropped the dead `ShowModal` type and `'tips'` id, and collapsed the duplicate `URL_SERIALIZABLE` set.

## Docs

`llms.txt` updated for the new packed `show=` forms; fixed stale canonical `show=maps`/`show=upload-track`.

## Verification

`npx tsgo --noEmit -p .` clean, `npx biome check` clean, tracking/gallery/selector reducer tests pass (79).

🤖 Generated with [Claude Code](https://claude.com/claude-code)