### PR TITLE
fix(routePlanner): bridge gaps between multimodal route segments

### DIFF
--- a/src/features/routePlanner/components/RoutePlannerResult.tsx
+++ b/src/features/routePlanner/components/RoutePlannerResult.tsx
@@ -692,13 +692,14 @@ export function RoutePlannerResult(): ReactElement {
                   // line on top, so the halo shows through as its edges.
                   <Polyline
                     key={`slice-${i}-${interactive}`}
-                    interactive={interactive}
+                    interactive={interactive && !routeSlice.connector}
                     ref={bringToFront}
                     positions={routeSlice.geometry.coordinates.map(reverse)}
                     weight={10}
                     color={
                       selectedSegment === routeSlice.legIndex &&
-                      alt === activeAlternativeIndex
+                      alt === activeAlternativeIndex &&
+                      !routeSlice.connector
                         ? '#156efd'
                         : '#fff'
                     }

--- a/src/features/routePlanner/model/actions.ts
+++ b/src/features/routePlanner/model/actions.ts
@@ -97,6 +97,11 @@ export interface Step {
     coordinates: StepCoordinate[];
   };
   extra?: RouteStepExtra;
+  /**
+   * Marks a synthetic straight bridge between two independently-routed
+   * segments. Rendered like a `manual` step but not selectable or draggable.
+   */
+  connector?: true;
 }
 
 export interface Alternative {

--- a/src/features/routePlanner/model/processors/findRouteProcessorHandler.ts
+++ b/src/features/routePlanner/model/processors/findRouteProcessorHandler.ts
@@ -371,11 +371,83 @@ const handle: ProcessorHandler = async ({ dispatch, getState, action }) => {
 
     const legs: Leg[] = [];
 
+    // A straight step between two points, accruing distance and (via `tpd`)
+    // duration like a manual route.
+    function straightStep(
+      from: [number, number],
+      to: [number, number],
+      mode: 'manual' | 'error',
+    ): Step {
+      const dist = distance(from, to, { units: 'meters' });
+
+      return {
+        distance: dist,
+        duration: tpd * dist,
+        maneuver: { type: 'continue', modifier: 'straight' },
+        mode,
+        name: '',
+        geometry: { coordinates: [from, to] },
+      };
+    }
+
+    // Draws straight `manual`/`error` legs between consecutive coordinates.
+    function pushStraightLegs(
+      coordinates: [number, number][],
+      mode: 'manual' | 'error',
+    ) {
+      for (let j = 0; j < coordinates.length - 1; j++) {
+        const step = straightStep(coordinates[j]!, coordinates[j + 1]!, mode);
+
+        legs.push({
+          distance: step.distance,
+          duration: step.duration,
+          steps: [step],
+        });
+      }
+    }
+
     for (const [i, segment] of segments.entries()) {
       const firstAlt = alternativeSets[i]?.[0];
 
       if (firstAlt && firstAlt.legs.length > 0) {
-        legs.push(...firstAlt.legs);
+        // Independently routed segments snap their shared waypoint to different
+        // networks, so a routed segment may start where the previous one ended
+        // with a gap. Bridge it with a straight `manual` connector, merged into
+        // the segment's first leg so it stays part of a real, selectable leg
+        // and doesn't shift the leg→point indexing that selection relies on.
+        const prevEnd = legs.at(-1)?.steps.at(-1)?.geometry.coordinates.at(-1);
+
+        const curStart = firstAlt.legs[0]?.steps[0]?.geometry.coordinates[0];
+
+        if (
+          prevEnd &&
+          curStart &&
+          (prevEnd[0] !== curStart[0] || prevEnd[1] !== curStart[1])
+        ) {
+          const connector: Step = {
+            ...straightStep(
+              [prevEnd[0], prevEnd[1]],
+              [curStart[0], curStart[1]],
+              'manual',
+            ),
+            connector: true,
+          };
+
+          const [first, ...rest] = firstAlt.legs;
+
+          legs.push(
+            {
+              ...first!,
+              distance: first!.distance + connector.distance,
+              duration: first!.duration + connector.duration,
+              steps: [connector, ...first!.steps],
+            },
+            ...rest,
+          );
+        } else {
+          legs.push(...firstAlt.legs);
+        }
+
         continue;
       }
 
@@ -404,31 +476,7 @@ const handle: ProcessorHandler = async ({ dispatch, getState, action }) => {
         }
       }
 
-      for (let j = 0; j < coordinates.length - 1; j++) {
-        const dist = distance(coordinates[j]!, coordinates[j + 1]!, {
-          units: 'meters',
-        });
-
-        const duration = tpd * dist;
-
-        legs.push({
-          distance: dist,
-          duration,
-
-          steps: [
-            {
-              distance: dist,
-              duration,
-              maneuver: { type: 'continue', modifier: 'straight' },
-              mode: errored[i] ? 'error' : 'manual',
-              name: '',
-              geometry: {
-                coordinates: coordinates.slice(j, j + 2),
-              },
-            },
-          ],
-        });
-      }
+      pushStraightLegs(coordinates, errored[i] ? 'error' : 'manual');
     }
 
     alternatives = [

--- a/src/features/routePlanner/model/processors/findRouteProcessorHandler.ts
+++ b/src/features/routePlanner/model/processors/findRouteProcessorHandler.ts
@@ -5,6 +5,7 @@ import type { RootState } from '@app/store/store.js';
 import { isPremium } from '@features/premium/premium.js';
 import { ToastAction, toastsAdd } from '@features/toasts/model/actions.js';
 import { isAnyOf } from '@reduxjs/toolkit';
+import { positionsEqual } from '@shared/geoutils.js';
 import { objectToURLSearchParams } from '@shared/stringUtils.js';
 import { TransportType, transportTypeDefs } from '@shared/transportTypeDefs.js';
 import distance from '@turf/distance';
@@ -419,11 +420,7 @@ const handle: ProcessorHandler = async ({ dispatch, getState, action }) => {
 
         const curStart = firstAlt.legs[0]?.steps[0]?.geometry.coordinates[0];
 
-        if (
-          prevEnd &&
-          curStart &&
-          (prevEnd[0] !== curStart[0] || prevEnd[1] !== curStart[1])
-        ) {
+        if (prevEnd && curStart && !positionsEqual(prevEnd, curStart)) {
           const connector: Step = {
             ...straightStep(
               [prevEnd[0], prevEnd[1]],


### PR DESCRIPTION
## Problem

In multimodal routing, each segment is queried independently per transport mode. Because each routing engine snaps the shared waypoint to its *own* network, the end of one segment and the start of the next can land on different points, leaving a visible gap between segments on the map.

## Fix

- Bridge the gap with a straight `manual` connector between the previous segment's end and the next segment's start.
- The connector is **merged into the next segment's first leg** (as its first step) rather than pushed as a standalone leg, so the leg→point indexing that leg selection relies on is preserved — selecting a segment no longer picks the wrong one.
- A new optional `Step.connector` marker tags the synthetic bridge so it renders dashed (like a `manual` step) but is **not selectable, draggable, or highlighted** — it's an artifact of independent routing, not a user-chosen segment.
- The connector still contributes to total time/distance.

## Notes

- Routed→synthetic and synthetic→routed transitions were already aligned by the existing fallback snapping, so no double-bridging occurs.
- You can no longer grab the route *exactly at the join* to drag a point, but the real segments on either side remain draggable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)