### PR TITLE
Move tracking show-line/show-points to the settings slice

### DIFF
--- a/src/app/store/middleware/statePersistingMiddleware.test.ts
+++ b/src/app/store/middleware/statePersistingMiddleware.test.ts
@@ -105,7 +105,12 @@ function makeState(): RootState {
       colorizeTrackBy: 'heartRate',
       colorizeLegend: true,
     },
-    trackingSettings: { colorizeBy: 'speed', colorizeLegend: true },
+    trackingSettings: {
+      colorizeBy: 'speed',
+      colorizeLegend: true,
+      showLine: false,
+      showPoints: false,
+    },
   } as unknown as RootState;
 }
 
@@ -228,7 +233,12 @@ describe('statePersistingMiddleware — what gets persisted', () => {
         colorizeTrackBy: 'heartRate',
         colorizeLegend: true,
       },
-      trackingSettings: { colorizeBy: 'speed', colorizeLegend: true },
+      trackingSettings: {
+        colorizeBy: 'speed',
+        colorizeLegend: true,
+        showLine: false,
+        showPoints: false,
+      },
     });
   });
 
@@ -322,8 +332,12 @@ describe('save → rehydrate round-trip', () => {
     expect(initial.gallerySettings?.recentTags).toEqual(['x']);
     // trackViewerSettings.colorizeTrackBy round-trips through save → rehydrate.
     expect(initial.trackViewerSettings?.colorizeTrackBy).toBe('heartRate');
-    // trackingSettings.colorizeBy round-trips through save → rehydrate.
+    // trackingSettings round-trips through save → rehydrate. The display prefs
+    // are non-default here on purpose: with the fixture's defaults they would
+    // round-trip even if they were dropped from the schema or the persist call.
     expect(initial.trackingSettings?.colorizeBy).toBe('speed');
+    expect(initial.trackingSettings?.showLine).toBe(false);
+    expect(initial.trackingSettings?.showPoints).toBe(false);
 
     // premiumExpiration round-trips Date → ISO string → Date.
     expect(initial.auth?.user?.premiumExpiration).toBeInstanceOf(Date);

--- a/src/app/store/persistence.ts
+++ b/src/app/store/persistence.ts
@@ -144,7 +144,11 @@ export const PersistedTrackViewerSettingsSchema = z
   .partial();
 
 export const PersistedTrackingSettingsSchema = z
-  .object(ColorizeSettingsShape)
+  .object({
+    ...ColorizeSettingsShape,
+    showLine: z.boolean(),
+    showPoints: z.boolean(),
+  })
   .partial();
 
 const MapDetailsSourceSchema = z.union([
@@ -349,6 +353,8 @@ const PERSIST: PersistEntry[] = [
     persist: (t) => ({
       colorizeBy: t.colorizeBy,
       colorizeLegend: t.colorizeLegend,
+      showLine: t.showLine,
+      showPoints: t.showPoints,
     }),
   }),
   defineEntry({

--- a/src/features/myMaps/model/actions.ts
+++ b/src/features/myMaps/model/actions.ts
@@ -25,9 +25,7 @@ export type MapMeta = z.infer<typeof MapMetaSchema>;
 export interface MapData<LT = Line, PT = DrawingPoint> {
   lines?: LT[];
   points?: PT[];
-  tracking?: Partial<
-    Pick<TrackingState, 'trackedDevices' | 'showLine' | 'showPoints'>
-  >;
+  tracking?: Partial<Pick<TrackingState, 'trackedDevices'>>;
   routePlanner?: Partial<
     Pick<
       RoutePlannerState,

--- a/src/features/myMaps/model/loadMapDocument.ts
+++ b/src/features/myMaps/model/loadMapDocument.ts
@@ -100,8 +100,6 @@ export const MapsLoadResponseSchema = z.object({
     tracking: z
       .object({
         trackedDevices: z.array(TrackedDeviceSchema).optional(),
-        showLine: z.boolean().optional(),
-        showPoints: z.boolean().optional(),
       })
       .optional(),
     routePlanner: RoutePlannerMapDataCompatSchema.optional(),

--- a/src/features/myMaps/model/processors/mapsSaveProcessor.ts
+++ b/src/features/myMaps/model/processors/mapsSaveProcessor.ts
@@ -93,8 +93,6 @@ function getMapDataFromState(state: RootState): MapData {
     points: drawingPoints.points,
     tracking: {
       trackedDevices: tracking.trackedDevices,
-      showLine: tracking.showLine,
-      showPoints: tracking.showPoints,
     },
     routePlanner: {
       transportType: routePlanner.transportType,

--- a/src/features/tracking/components/TrackingMenu.tsx
+++ b/src/features/tracking/components/TrackingMenu.tsx
@@ -47,9 +47,11 @@ export function TrackingMenu(): ReactElement {
 
   const dispatch = useDispatch();
 
-  const showPoints = useAppSelector((state) => state.tracking.showPoints);
+  const showPoints = useAppSelector(
+    (state) => state.trackingSettings.showPoints,
+  );
 
-  const showLine = useAppSelector((state) => state.tracking.showLine);
+  const showLine = useAppSelector((state) => state.trackingSettings.showLine);
 
   const colorizeBy = useAppSelector(
     (state) => state.trackingSettings.colorizeBy,

--- a/src/features/tracking/components/TrackingResult.tsx
+++ b/src/features/tracking/components/TrackingResult.tsx
@@ -78,9 +78,11 @@ export function TrackingResult(): ReactElement {
 
   const language = useAppSelector((state) => state.l10n.language);
 
-  const showLine = useAppSelector((state) => state.tracking.showLine);
+  const showLine = useAppSelector((state) => state.trackingSettings.showLine);
 
-  const showPoints = useAppSelector((state) => state.tracking.showPoints);
+  const showPoints = useAppSelector(
+    (state) => state.trackingSettings.showPoints,
+  );
 
   const trackedDevices = useAppSelector(
     (state) => state.tracking.trackedDevices,

--- a/src/features/tracking/model/reducer.test.ts
+++ b/src/features/tracking/model/reducer.test.ts
@@ -4,10 +4,6 @@ import { wsStateChanged } from '@features/websocket/model/actions.js';
 import { describe, expect, it } from 'vitest';
 import { trackingActions } from './actions.js';
 import { trackingReducer } from './reducer.js';
-import {
-  trackingSettingsInitialState,
-  trackingSettingsReducer,
-} from './settingsReducer.js';
 import type { Track, TrackedDevice } from './types.js';
 
 /**
@@ -142,20 +138,6 @@ describe('trackingReducer — device editor state', () => {
     expect(next.devices).toEqual([]);
     expect(next.modifiedDeviceId).toBeUndefined();
     expect(next.accessTokensDeviceId).toBeUndefined();
-  });
-
-  it('setShowPoints / setShowLine store the flags in the settings slice', () => {
-    const off = trackingSettingsReducer(
-      trackingSettingsInitialState,
-      trackingActions.setShowPoints(false),
-    );
-    expect(off.showPoints).toBe(false);
-
-    const line = trackingSettingsReducer(
-      trackingSettingsInitialState,
-      trackingActions.setShowLine(false),
-    );
-    expect(line.showLine).toBe(false);
   });
 });
 

--- a/src/features/tracking/model/reducer.test.ts
+++ b/src/features/tracking/model/reducer.test.ts
@@ -4,6 +4,10 @@ import { wsStateChanged } from '@features/websocket/model/actions.js';
 import { describe, expect, it } from 'vitest';
 import { trackingActions } from './actions.js';
 import { trackingReducer } from './reducer.js';
+import {
+  trackingSettingsInitialState,
+  trackingSettingsReducer,
+} from './settingsReducer.js';
 import type { Track, TrackedDevice } from './types.js';
 
 /**
@@ -33,8 +37,6 @@ const withTracks = (tracks: Track[]) => ({
   modifiedAccessTokenId: undefined,
   trackedDevices: [],
   tracks,
-  showLine: true,
-  showPoints: true,
 });
 
 describe('trackingReducer — tracked devices', () => {
@@ -142,15 +144,15 @@ describe('trackingReducer — device editor state', () => {
     expect(next.accessTokensDeviceId).toBeUndefined();
   });
 
-  it('setShowPoints / setShowLine store the flags', () => {
-    const off = trackingReducer(
-      withTracks([]),
+  it('setShowPoints / setShowLine store the flags in the settings slice', () => {
+    const off = trackingSettingsReducer(
+      trackingSettingsInitialState,
       trackingActions.setShowPoints(false),
     );
     expect(off.showPoints).toBe(false);
 
-    const line = trackingReducer(
-      withTracks([]),
+    const line = trackingSettingsReducer(
+      trackingSettingsInitialState,
       trackingActions.setShowLine(false),
     );
     expect(line.showLine).toBe(false);

--- a/src/features/tracking/model/reducer.ts
+++ b/src/features/tracking/model/reducer.ts
@@ -28,8 +28,6 @@ export interface TrackingState {
   modifiedAccessTokenId: number | null | undefined;
   trackedDevices: TrackedDevice[];
   tracks: Track[];
-  showLine: boolean;
-  showPoints: boolean;
 }
 
 export const trackingInitialState: TrackingState = {
@@ -40,8 +38,6 @@ export const trackingInitialState: TrackingState = {
   modifiedAccessTokenId: undefined,
   trackedDevices: [],
   tracks: [],
-  showLine: true,
-  showPoints: true,
 };
 
 export const trackingReducer = createReducer(trackingInitialState, (builder) =>
@@ -101,14 +97,6 @@ export const trackingReducer = createReducer(trackingInitialState, (builder) =>
     .addCase(trackingActions.deleteTrackedDevice, (state, { payload }) => ({
       ...state,
       trackedDevices: state.trackedDevices.filter((d) => d.token !== payload),
-    }))
-    .addCase(trackingActions.setShowPoints, (state, { payload }) => ({
-      ...state,
-      showPoints: payload,
-    }))
-    .addCase(trackingActions.setShowLine, (state, { payload }) => ({
-      ...state,
-      showLine: payload,
     }))
     .addCase(wsStateChanged, (state, { payload }) =>
       payload.state === 1 ? state : { ...state, tracks: [] },
@@ -198,8 +186,6 @@ export const trackingReducer = createReducer(trackingInitialState, (builder) =>
             ...(tracking?.trackedDevices ??
               trackingInitialState.trackedDevices),
           ],
-          showLine: tracking?.showLine ?? trackingInitialState.showLine,
-          showPoints: tracking?.showPoints ?? trackingInitialState.showPoints,
         };
       },
     ),

--- a/src/features/tracking/model/settingsReducer.test.ts
+++ b/src/features/tracking/model/settingsReducer.test.ts
@@ -32,4 +32,20 @@ describe('trackingSettingsReducer', () => {
     );
     expect(explicit.colorizeLegend).toBe(false);
   });
+
+  it('setShowPoints / setShowLine store the display flags', () => {
+    const off = trackingSettingsReducer(
+      trackingSettingsInitialState,
+      trackingActions.setShowPoints(false),
+    );
+
+    expect(off.showPoints).toBe(false);
+
+    const line = trackingSettingsReducer(
+      trackingSettingsInitialState,
+      trackingActions.setShowLine(false),
+    );
+
+    expect(line.showLine).toBe(false);
+  });
 });

--- a/src/features/tracking/model/settingsReducer.ts
+++ b/src/features/tracking/model/settingsReducer.ts
@@ -10,11 +10,17 @@ export interface TrackingSettingsState {
   colorizeBy: ColorizingMode | null;
   // Whether the colorize legend is shown; independent of the other tools.
   colorizeLegend: boolean;
+  // How tracked devices are drawn — a display preference of the viewer, not a
+  // property of any particular map.
+  showLine: boolean;
+  showPoints: boolean;
 }
 
 export const trackingSettingsInitialState: TrackingSettingsState = {
   colorizeBy: null,
   colorizeLegend: true,
+  showLine: true,
+  showPoints: true,
 };
 
 export const trackingSettingsReducer = createReducer(
@@ -26,5 +32,11 @@ export const trackingSettingsReducer = createReducer(
       })
       .addCase(trackingActions.setColorizeLegend, (state, { payload }) => {
         toggleColorizeLegend(state, payload);
+      })
+      .addCase(trackingActions.setShowLine, (state, { payload }) => {
+        state.showLine = payload;
+      })
+      .addCase(trackingActions.setShowPoints, (state, { payload }) => {
+        state.showPoints = payload;
       }),
 );


### PR DESCRIPTION
## Summary

`showLine` / `showPoints` control how tracked devices are drawn — a display preference of the viewer, not a property of any particular map. But they lived in the **transient** `tracking` slice, which `clearMapFeatures` resets, and were written into **each saved map document** rather than localStorage.

Their two siblings, `colorizeBy` and `colorizeLegend`, already sit in `trackingSettings`. The settings-slice convention (CLAUDE.md) exists precisely so a preference isn't clobbered by a map clear.

- Move both flags to `trackingSettings` and persist them there, alongside the colorize prefs.
- Stop writing them into the map document (`MapData`, `getMapDataFromState`, and the loader schema); older documents simply have the field ignored.
- The reducer test moves to the settings reducer.

Split out of #944 so that PR is only the my-maps unsaved-changes work.

## Test plan

- [ ] Toggle show-points off, reload the page → still off (it's now a global preference, not per-map)
- [ ] Toggle show-line off, open a different map → still off
- [ ] Clear map elements → the toggles keep their values
- [ ] Open a map saved before this change → loads without error, toggles keep the user's own values

🤖 Generated with [Claude Code](https://claude.com/claude-code)