### PR TITLE
feat(location): show a heading beam on the located position

### DIFF
--- a/src/app/components/LocationResult.tsx
+++ b/src/app/components/LocationResult.tsx
@@ -1,14 +1,7 @@
-import type { Heading } from '@features/location/hooks/useHeading.js';
 import { useHeading } from '@features/location/hooks/useHeading.js';
 import { useAppSelector } from '@shared/hooks/useAppSelector.js';
 import { divIcon, type Marker as LeafletMarker } from 'leaflet';
-import {
-  type ReactElement,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-} from 'react';
+import { type ReactElement, useEffect, useMemo, useRef } from 'react';
 import { Circle, Marker } from 'react-leaflet';
 
 const circularIcon = divIcon({
@@ -27,11 +20,8 @@ const circularIcon = divIcon({
 });
 
 const BEAM_SIZE = 120;
-
 const BEAM_RADIUS = 52;
-
 const MIN_SPREAD = 12;
-
 const MAX_SPREAD = 60;
 
 const clampSpread = (spread: number) =>
@@ -46,11 +36,8 @@ function makeBeamIcon(spread: number) {
   const half = (spread * Math.PI) / 180;
 
   const x1 = (BEAM_RADIUS * Math.sin(-half)).toFixed(2);
-
   const y1 = (-BEAM_RADIUS * Math.cos(-half)).toFixed(2);
-
   const x2 = (BEAM_RADIUS * Math.sin(half)).toFixed(2);
-
   const y2 = (-BEAM_RADIUS * Math.cos(half)).toFixed(2);
 
   // `display:block` on the svg is load-bearing: inline it would sit on the text
@@ -61,14 +48,14 @@ function makeBeamIcon(spread: number) {
     iconSize: [BEAM_SIZE, BEAM_SIZE],
     iconAnchor: [BEAM_SIZE / 2, BEAM_SIZE / 2],
     html: `<div style="transform-origin:50% 50%">
-  <svg style="display:block" xmlns="http://www.w3.org/2000/svg" width="${BEAM_SIZE}" height="${BEAM_SIZE}" viewBox="${-BEAM_SIZE / 2} ${-BEAM_SIZE / 2} ${BEAM_SIZE} ${BEAM_SIZE}">
-    <radialGradient id="fm-heading-beam" gradientUnits="userSpaceOnUse" cx="0" cy="0" r="${BEAM_RADIUS}">
-      <stop offset="0.2" stop-color="#3388ff" stop-opacity=".75"/>
-      <stop offset="1" stop-color="#3388ff" stop-opacity="0"/>
-    </radialGradient>
-    <path fill="url(#fm-heading-beam)" d="M0 0L${x1} ${y1}A${BEAM_RADIUS} ${BEAM_RADIUS} 0 0 1 ${x2} ${y2}Z"/>
-  </svg>
-</div>`,
+      <svg style="display:block" xmlns="http://www.w3.org/2000/svg" width="${BEAM_SIZE}" height="${BEAM_SIZE}" viewBox="${-BEAM_SIZE / 2} ${-BEAM_SIZE / 2} ${BEAM_SIZE} ${BEAM_SIZE}">
+        <radialGradient id="fm-heading-beam" gradientUnits="userSpaceOnUse" cx="0" cy="0" r="${BEAM_RADIUS}">
+          <stop offset="0.2" stop-color="#3388ff" stop-opacity=".75"/>
+          <stop offset="1" stop-color="#3388ff" stop-opacity="0"/>
+        </radialGradient>
+        <path fill="url(#fm-heading-beam)" d="M0 0L${x1} ${y1}A${BEAM_RADIUS} ${BEAM_RADIUS} 0 0 1 ${x2} ${y2}Z"/>
+      </svg>
+    </div>`,
   });
 }
 
@@ -96,23 +83,13 @@ export function LocationResult(): ReactElement | null {
   // circle and both markers on every one of the ~10 heading updates a second,
   // re-projecting the circle's path each time.
   const position = useMemo(
-    () =>
-      gpsLocation === null
-        ? null
-        : { lat: gpsLocation.lat, lng: gpsLocation.lon },
+    () => gpsLocation && { lat: gpsLocation.lat, lng: gpsLocation.lon },
     [gpsLocation],
   );
 
   // Rotate by mutating the element instead of rebuilding the icon, which would
   // tear down and re-add the DOM node on every one of the ~10 updates a second.
-  const rotate = useCallback((to: Heading | null) => {
-    const wrapper = beamRef.current?.getElement()?.firstElementChild;
-
-    if (wrapper instanceof HTMLElement && to) {
-      wrapper.style.transform = `rotate(${to.value.toFixed(1)}deg)`;
-    }
-  }, []);
-
+  //
   // `hasFix` is a dependency in its own right: the marker mounts afresh whenever
   // the fix returns from null — every locate start, since `toggleLocate` clears
   // the location — while a settled heading is referentially unchanged at that
@@ -122,8 +99,12 @@ export function LocationResult(): ReactElement | null {
   // layer in a passive one, so the element does not exist yet at that point.
   // This effect is passive and belongs to the parent, so it runs after it does.
   useEffect(() => {
-    rotate(hasFix ? heading : null);
-  }, [heading, hasFix, rotate]);
+    const wrapper = beamRef.current?.getElement()?.firstElementChild;
+
+    if (wrapper instanceof HTMLElement && hasFix && heading) {
+      wrapper.style.transform = `rotate(${heading.value.toFixed(1)}deg)`;
+    }
+  }, [heading, hasFix]);
 
   return !gpsLocation || !position ? null : (
     <>

--- a/src/app/components/LocationResult.tsx
+++ b/src/app/components/LocationResult.tsx
@@ -1,6 +1,14 @@
+import type { Heading } from '@features/location/hooks/useHeading.js';
+import { useHeading } from '@features/location/hooks/useHeading.js';
 import { useAppSelector } from '@shared/hooks/useAppSelector.js';
-import { divIcon } from 'leaflet';
-import type { ReactElement } from 'react';
+import { divIcon, type Marker as LeafletMarker } from 'leaflet';
+import {
+  type ReactElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
 import { Circle, Marker } from 'react-leaflet';
 
 const circularIcon = divIcon({
@@ -18,22 +26,126 @@ const circularIcon = divIcon({
 </svg>`,
 });
 
+const BEAM_SIZE = 120;
+
+const BEAM_RADIUS = 52;
+
+const MIN_SPREAD = 12;
+
+const MAX_SPREAD = 60;
+
+const clampSpread = (spread: number) =>
+  Math.min(Math.max(spread, MIN_SPREAD), MAX_SPREAD);
+
+/**
+ * A wedge fading outwards, drawn pointing north; the marker element is then
+ * rotated to the heading. Its width doubles as the uncertainty readout — narrow
+ * for a well-calibrated compass, wide when falling back to the GPS course.
+ */
+function makeBeamIcon(spread: number) {
+  const half = (spread * Math.PI) / 180;
+
+  const x1 = (BEAM_RADIUS * Math.sin(-half)).toFixed(2);
+
+  const y1 = (-BEAM_RADIUS * Math.cos(-half)).toFixed(2);
+
+  const x2 = (BEAM_RADIUS * Math.sin(half)).toFixed(2);
+
+  const y2 = (-BEAM_RADIUS * Math.cos(half)).toFixed(2);
+
+  // `display:block` on the svg is load-bearing: inline it would sit on the text
+  // baseline, leaving the wrapper taller than the svg (`.leaflet-container` sets
+  // `line-height: 1.5`) so `transform-origin: 50% 50%` would rotate about a
+  // point below the marker anchor and swing the apex off the crosshair.
+  return divIcon({
+    iconSize: [BEAM_SIZE, BEAM_SIZE],
+    iconAnchor: [BEAM_SIZE / 2, BEAM_SIZE / 2],
+    html: `<div style="transform-origin:50% 50%">
+  <svg style="display:block" xmlns="http://www.w3.org/2000/svg" width="${BEAM_SIZE}" height="${BEAM_SIZE}" viewBox="${-BEAM_SIZE / 2} ${-BEAM_SIZE / 2} ${BEAM_SIZE} ${BEAM_SIZE}">
+    <radialGradient id="fm-heading-beam" gradientUnits="userSpaceOnUse" cx="0" cy="0" r="${BEAM_RADIUS}">
+      <stop offset="0.2" stop-color="#3388ff" stop-opacity=".75"/>
+      <stop offset="1" stop-color="#3388ff" stop-opacity="0"/>
+    </radialGradient>
+    <path fill="url(#fm-heading-beam)" d="M0 0L${x1} ${y1}A${BEAM_RADIUS} ${BEAM_RADIUS} 0 0 1 ${x2} ${y2}Z"/>
+  </svg>
+</div>`,
+  });
+}
+
 export function LocationResult(): ReactElement | null {
   const gpsLocation = useAppSelector((state) => state.location.location);
 
-  return !gpsLocation ? null : (
+  const heading = useHeading();
+
+  const hasFix = gpsLocation !== null;
+
+  const beamRef = useRef<LeafletMarker | null>(null);
+
+  // Only the width changes the geometry; the angle is applied by rotation. Keyed
+  // on the clamped value, since two raw accuracies that clamp alike draw the
+  // same wedge and rebuilding the icon for them is pure churn — `setIcon`
+  // rewrites the element's `innerHTML`.
+  const spread = heading === null ? null : clampSpread(heading.spread);
+
+  const beamIcon = useMemo(
+    () => (spread === null ? null : makeBeamIcon(spread)),
+    [spread],
+  );
+
+  // Leaflet compares by reference, so a fresh literal per render would move the
+  // circle and both markers on every one of the ~10 heading updates a second,
+  // re-projecting the circle's path each time.
+  const position = useMemo(
+    () =>
+      gpsLocation === null
+        ? null
+        : { lat: gpsLocation.lat, lng: gpsLocation.lon },
+    [gpsLocation],
+  );
+
+  // Rotate by mutating the element instead of rebuilding the icon, which would
+  // tear down and re-add the DOM node on every one of the ~10 updates a second.
+  const rotate = useCallback((to: Heading | null) => {
+    const wrapper = beamRef.current?.getElement()?.firstElementChild;
+
+    if (wrapper instanceof HTMLElement && to) {
+      wrapper.style.transform = `rotate(${to.value.toFixed(1)}deg)`;
+    }
+  }, []);
+
+  // `hasFix` is a dependency in its own right: the marker mounts afresh whenever
+  // the fix returns from null — every locate start, since `toggleLocate` clears
+  // the location — while a settled heading is referentially unchanged at that
+  // commit, so keying on `heading` alone would leave the new element pointing
+  // north until the heading next moved. A ref callback cannot stand in for this:
+  // react-leaflet attaches the forwarded ref in a layout effect but adds the
+  // layer in a passive one, so the element does not exist yet at that point.
+  // This effect is passive and belongs to the parent, so it runs after it does.
+  useEffect(() => {
+    rotate(hasFix ? heading : null);
+  }, [heading, hasFix, rotate]);
+
+  return !gpsLocation || !position ? null : (
     <>
+      {/* `accuracy` is already the radius of the 95%-confidence circle */}
       <Circle
-        center={{ lat: gpsLocation.lat, lng: gpsLocation.lon }}
-        radius={gpsLocation.accuracy / 2}
+        center={position}
+        radius={gpsLocation.accuracy}
         weight={1}
         stroke={false}
       />
 
-      <Marker
-        icon={circularIcon}
-        position={{ lat: gpsLocation.lat, lng: gpsLocation.lon }}
-      />
+      {beamIcon && (
+        <Marker
+          ref={beamRef}
+          icon={beamIcon}
+          position={position}
+          interactive={false}
+          zIndexOffset={-1}
+        />
+      )}
+
+      <Marker icon={circularIcon} position={position} />
     </>
   );
 }

--- a/src/app/components/MapControls.tsx
+++ b/src/app/components/MapControls.tsx
@@ -1,4 +1,5 @@
 import { useMessages } from '@features/l10n/l10nInjector.js';
+import { ensureCompassPermission } from '@features/location/ensureCompassPermission.js';
 import { useMap } from '@features/map/hooks/useMap.js';
 import { type MapViewState, mapRefocus } from '@features/map/model/actions.js';
 import { LongPressTooltip } from '@shared/components/LongPressTooltip.js';
@@ -24,6 +25,21 @@ export function MapControls(): ReactElement | null {
   const locate = useAppSelector((state) => state.location.locate);
 
   const gpsTracked = useAppSelector((state) => state.map.gpsTracked);
+
+  const headingSource = useAppSelector(
+    (state) => state.locationSettings.headingSource,
+  );
+
+  const handleLocateClick = useCallback(() => {
+    // iOS forgets the orientation grant between page loads while the preference
+    // survives, so a stored compass choice needs a gesture to revive it; this is
+    // the earliest one that means "I want to be located".
+    if (!locate && headingSource === 'compass') {
+      ensureCompassPermission(dispatch);
+    }
+
+    dispatch(toggleLocate(undefined));
+  }, [dispatch, headingSource, locate]);
 
   const onMapRefocus = useCallback(
     (changes: Partial<MapViewState>) => {
@@ -105,9 +121,7 @@ export function MapControls(): ReactElement | null {
           {({ props }) => (
             <Button
               className="ms-1"
-              onClick={() => {
-                dispatch(toggleLocate(undefined));
-              }}
+              onClick={handleLocateClick}
               active={locate}
               variant={gpsTracked ? 'warning' : 'secondary'}
               {...props}

--- a/src/app/store/actions.ts
+++ b/src/app/store/actions.ts
@@ -8,7 +8,11 @@ import {
   saveHomeLocation,
   setSelectingHomeLocation,
 } from '@features/homeLocation/model/actions.js';
-import { setLocation, toggleLocate } from '@features/location/model/actions.js';
+import {
+  locationSetHeadingSource,
+  setLocation,
+  toggleLocate,
+} from '@features/location/model/actions.js';
 import type { LayerSettings } from '@features/map/model/actions.js';
 import { createAction } from '@reduxjs/toolkit';
 import type { CustomLayerDef } from '@shared/mapDefinitions.js';
@@ -58,7 +62,12 @@ export const clearMapFeatures = createAction('CLEAR_MAP_FEATURES');
 /** Drops the persisted local settings and reloads the app from defaults. */
 export const resetApp = createAction('RESET_APP');
 
-export { saveHomeLocation, setSelectingHomeLocation, toggleLocate };
+export {
+  locationSetHeadingSource,
+  saveHomeLocation,
+  setSelectingHomeLocation,
+  toggleLocate,
+};
 
 type Settings = {
   layersSettings?: Record<string, LayerSettings>;

--- a/src/app/store/middleware/statePersistingMiddleware.test.ts
+++ b/src/app/store/middleware/statePersistingMiddleware.test.ts
@@ -21,7 +21,18 @@ function makeState(): RootState {
     main: { hiddenInfoBars: { foo: 1 } },
     homeLocation: { homeLocation: { lat: 1, lon: 2 } },
     // In state but not persisted (no PERSIST entry).
-    location: { locate: true, location: { lat: 1, lon: 2, accuracy: 5 } },
+    location: {
+      locate: true,
+      location: {
+        lat: 1,
+        lon: 2,
+        accuracy: 5,
+        heading: null,
+        speed: null,
+        at: 0,
+      },
+    },
+    locationSettings: { headingSource: 'compass' },
     cookieConsent: { cookieConsentResult: true, analyticCookiesAllowed: false },
     drawingSettings: {
       style: {
@@ -201,6 +212,7 @@ describe('statePersistingMiddleware — what gets persisted', () => {
         resolutionScale: null,
         featureScale: 1,
       },
+      locationSettings: { headingSource: 'compass' },
       gallerySettings: {
         colorizeBy: null,
         recentTags: ['x'],
@@ -257,6 +269,7 @@ describe('statePersistingMiddleware — what gets persisted', () => {
         'drawingSettings',
         'homeLocation',
         'l10n',
+        'locationSettings',
         'main',
         'map',
         'mapDetails',

--- a/src/app/store/persistence.ts
+++ b/src/app/store/persistence.ts
@@ -11,6 +11,10 @@ import { GalleryColorizeBySchema } from '@features/gallery/model/actions.js';
 import { gallerySettingsInitialState } from '@features/gallery/model/settingsReducer.js';
 import { homeLocationInitialState } from '@features/homeLocation/model/reducer.js';
 import { l10nInitialState } from '@features/l10n/model/reducer.js';
+import {
+  HeadingSourceSchema,
+  locationSettingsInitialState,
+} from '@features/location/model/settingsReducer.js';
 import { LayerSettingsSchema } from '@features/map/model/actions.js';
 import { mapInitialState } from '@features/map/model/reducer.js';
 import { mapDetailsInitialState } from '@features/mapDetails/model/reducer.js';
@@ -164,6 +168,10 @@ export const PersistedMapDetailsSchema = z
   .object({
     excludeSources: z.array(MapDetailsSourceSchema),
   })
+  .partial();
+
+export const PersistedLocationSettingsSchema = z
+  .object({ headingSource: HeadingSourceSchema })
   .partial();
 
 export const PersistedGallerySettingsSchema = z
@@ -362,6 +370,12 @@ const PERSIST: PersistEntry[] = [
     schema: PersistedMapDetailsSchema,
     initial: mapDetailsInitialState,
     persist: (m) => ({ excludeSources: m.excludeSources }),
+  }),
+  defineEntry({
+    key: 'locationSettings',
+    schema: PersistedLocationSettingsSchema,
+    initial: locationSettingsInitialState,
+    persist: (l) => ({ headingSource: l.headingSource }),
   }),
   defineEntry({
     key: 'gallerySettings',

--- a/src/app/store/rootReducer.ts
+++ b/src/app/store/rootReducer.ts
@@ -12,6 +12,7 @@ import { geoIpReducer } from '@features/geoip/model/reducer.js';
 import { homeLocationReducer } from '@features/homeLocation/model/reducer.js';
 import { l10nReducer } from '@features/l10n/model/reducer.js';
 import { locationReducer } from '@features/location/model/reducer.js';
+import { locationSettingsReducer } from '@features/location/model/settingsReducer.js';
 import { mapReducer } from '@features/map/model/reducer.js';
 import { mapAreaReducer } from '@features/mapArea/model/reducer.js';
 import { mapDetailsReducer } from '@features/mapDetails/model/reducer.js';
@@ -49,6 +50,7 @@ export const reducers = {
   homeLocation: homeLocationReducer,
   l10n: l10nReducer,
   location: locationReducer,
+  locationSettings: locationSettingsReducer,
   main: mainReducer,
   mapDetails: mapDetailsReducer,
   mapArea: mapAreaReducer,

--- a/src/features/location/compass.ts
+++ b/src/features/location/compass.ts
@@ -1,0 +1,219 @@
+/**
+ * Device-magnetometer heading, normalized across the two incompatible browser
+ * APIs: iOS' `webkitCompassHeading` and the W3C absolute `deviceorientation`
+ * Euler angles.
+ *
+ * All headings are degrees in `[0, 360)`, clockwise, and referenced to the
+ * screen's "up" direction (so they stay correct in landscape). Note the north
+ * they are referenced to differs by platform — see `readAbsolute`.
+ */
+
+export type CompassReading = {
+  heading: number;
+  /** Half-angle of the reported uncertainty in degrees; `null` when the platform reports none. */
+  accuracy: number | null;
+  /** `performance.now()` stamp, for staleness checks. */
+  at: number;
+};
+
+type IosDeviceOrientationEvent = DeviceOrientationEvent & {
+  webkitCompassHeading?: number;
+  webkitCompassAccuracy?: number;
+};
+
+type PermissionCapable = {
+  requestPermission?: () => Promise<PermissionState>;
+};
+
+const DEG = Math.PI / 180;
+
+/**
+ * A relative alpha has an arbitrary origin and is useless as a compass — but
+ * Chrome's DevTools sensor emulation only ever produces relative events, so dev
+ * builds take them anyway to keep this testable without a phone. Keyed off
+ * `DEPLOYMENT` (which `EnvironmentPlugin` always defines) the same way
+ * `rspack.config.ts` decides on a production build.
+ */
+const ACCEPT_RELATIVE =
+  !process.env['DEPLOYMENT'] || process.env['DEPLOYMENT'] === 'dev';
+
+/**
+ * Desktop Chrome exposes `DeviceOrientationEvent` while having no magnetometer
+ * behind it, so the API check alone would offer the option everywhere. A touch
+ * input being present is the closest proxy for a device that actually has one —
+ * `any-pointer` rather than `pointer`, since an iPad with a trackpad attached
+ * reports a fine *primary* pointer while still carrying a working compass.
+ */
+export function isCompassSupported(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    'DeviceOrientationEvent' in window &&
+    // guarded because this runs at module load, where the host need not be a
+    // full browser — jsdom, for one, ships no `matchMedia`
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(any-pointer: coarse)').matches
+  );
+}
+
+/**
+ * Whether the platform gates orientation events behind a prompt — true on
+ * iOS 13+, false everywhere else. A capability test rather than UA sniffing,
+ * and the reason the compass is opt-in at all.
+ */
+export function isCompassPermissionRequired(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof (window.DeviceOrientationEvent as unknown as PermissionCapable)
+      ?.requestPermission === 'function'
+  );
+}
+
+/**
+ * iOS 13+ gates orientation events behind a permission that may only be
+ * requested from a user gesture, so this must be called straight out of a click
+ * handler (a promise chain from one is fine, a timeout is not). Everywhere else
+ * it resolves `true` without prompting.
+ */
+export function requestCompassPermission(): Promise<boolean> {
+  const request = (
+    window.DeviceOrientationEvent as unknown as PermissionCapable | undefined
+  )?.requestPermission;
+
+  if (typeof request !== 'function') {
+    return Promise.resolve(isCompassSupported());
+  }
+
+  return request
+    .call(window.DeviceOrientationEvent)
+    .then((state) => state === 'granted')
+    .catch(() => false);
+}
+
+/** Screen rotation relative to the device chassis, in degrees. */
+function screenAngle(): number {
+  return screen.orientation?.angle ?? 0;
+}
+
+/**
+ * Heading of the direction the user faces, from the W3C Euler angles.
+ *
+ * Two device axes can stand for "forward", each degenerate where the other
+ * works: the screen's up vector (right when the phone lies flat, meaningless
+ * when it is held upright) and the screen normal pointing out of the back
+ * (right when upright, meaningless when flat). Summing their horizontal
+ * projections blends between them by tilt for free — near either extreme the
+ * degenerate term projects to roughly nothing, and in between both agree.
+ */
+function tiltCompensatedHeading(
+  alpha: number,
+  beta: number,
+  gamma: number,
+): number {
+  const cA = Math.cos(alpha * DEG);
+  const sA = Math.sin(alpha * DEG);
+  const cB = Math.cos(beta * DEG);
+  const sB = Math.sin(beta * DEG);
+  const cG = Math.cos(gamma * DEG);
+  const sG = Math.sin(gamma * DEG);
+
+  // Columns of the device→Earth rotation matrix R = Rz(alpha)·Rx(beta)·Ry(gamma),
+  // in the Earth frame where x points east, y north and z up.
+  const xCol = [cA * cG - sA * sB * sG, cG * sA + cA * sB * sG];
+  const yCol = [-cB * sA, cA * cB];
+  const zCol = [cA * sG + cG * sA * sB, sA * sG - cA * cG * sB];
+
+  // The screen's up vector in device coordinates, so landscape stays correct.
+  const a = screenAngle() * DEG;
+  const su = Math.sin(a);
+  const cu = Math.cos(a);
+
+  const east = su * xCol[0]! + cu * yCol[0]! - zCol[0]!;
+  const north = su * xCol[1]! + cu * yCol[1]! - zCol[1]!;
+
+  return (Math.atan2(east, north) / DEG + 360) % 360;
+}
+
+function readEvent(e: DeviceOrientationEvent): CompassReading | null {
+  const { webkitCompassHeading: iosHeading, webkitCompassAccuracy } =
+    e as IosDeviceOrientationEvent;
+
+  if (typeof iosHeading === 'number' && !Number.isNaN(iosHeading)) {
+    // iOS reports the heading ready-made, clockwise from north, referenced to
+    // the device held in portrait — hence the screen-rotation term. Unlike the
+    // Euler path below this is true north (it falls back to magnetic north when
+    // location services are off).
+    return {
+      heading: (iosHeading + screenAngle() + 360) % 360,
+      // documented as -1 when the magnetometer is not calibrated
+      accuracy:
+        typeof webkitCompassAccuracy === 'number' && webkitCompassAccuracy >= 0
+          ? webkitCompassAccuracy
+          : null,
+      at: performance.now(),
+    };
+  }
+
+  if (e.alpha === null || e.beta === null || e.gamma === null) {
+    return null;
+  }
+
+  if (!e.absolute && !ACCEPT_RELATIVE) {
+    return null;
+  }
+
+  // The absolute frame is magnetic-north referenced, so this path is off from
+  // the GPS course by the local declination (~5° in Slovakia).
+
+  return {
+    heading: tiltCompensatedHeading(e.alpha, e.beta, e.gamma),
+    accuracy: null,
+    at: performance.now(),
+  };
+}
+
+/**
+ * Subscribes to compass readings. Listens to both event types rather than
+ * picking one up front: `ondeviceorientationabsolute` being present is no
+ * promise that it ever fires, and iOS only fires the plain event. Absolute
+ * readings win once any have arrived.
+ */
+export function subscribeCompass(
+  onReading: (reading: CompassReading) => void,
+): () => void {
+  let sawAbsolute = false;
+
+  const handler = (fromAbsoluteEvent: boolean) => (e: Event) => {
+    if (!fromAbsoluteEvent && sawAbsolute) {
+      return;
+    }
+
+    const reading = readEvent(e as DeviceOrientationEvent);
+
+    if (!reading) {
+      return;
+    }
+
+    // Latch on a usable reading, never on the bare event: a device with no
+    // magnetometer still fires `deviceorientationabsolute` once with null
+    // angles, which would otherwise mute the fallback stream for good.
+    if (fromAbsoluteEvent) {
+      sawAbsolute = true;
+    }
+
+    onReading(reading);
+  };
+
+  const onAbsolute = handler(true);
+
+  const onPlain = handler(false);
+
+  window.addEventListener('deviceorientationabsolute', onAbsolute);
+
+  window.addEventListener('deviceorientation', onPlain);
+
+  return () => {
+    window.removeEventListener('deviceorientationabsolute', onAbsolute);
+
+    window.removeEventListener('deviceorientation', onPlain);
+  };
+}

--- a/src/features/location/ensureCompassPermission.ts
+++ b/src/features/location/ensureCompassPermission.ts
@@ -1,0 +1,46 @@
+import { toastsAdd } from '@features/toasts/model/actions.js';
+import type { Dispatch } from '@reduxjs/toolkit';
+import {
+  isCompassPermissionRequired,
+  requestCompassPermission,
+} from './compass.js';
+import { locationSetHeadingSource } from './model/actions.js';
+
+/**
+ * Re-acquires the orientation grant from whatever user gesture is at hand.
+ *
+ * iOS drops the grant between page loads while the preference survives in
+ * localStorage, so a stored `compass` choice would otherwise be dead on every
+ * fresh visit — no events, just the "no compass data" toast — until the user
+ * happened to reopen the preferences. Call this from any gesture that means the
+ * user wants the compass now.
+ *
+ * A refusal downgrades the preference: `requestPermission` keeps returning
+ * `denied` without re-prompting, so leaving `compass` selected would sit there
+ * silently dead and re-toast on every locate.
+ */
+export function ensureCompassPermission(dispatch: Dispatch): void {
+  // Nothing to ask for off iOS, and asking anyway would misread the "device has
+  // no compass" answer `requestCompassPermission` falls back to as a refusal —
+  // downgrading the preference and blaming the user for a prompt never shown.
+  if (!isCompassPermissionRequired()) {
+    return;
+  }
+
+  requestCompassPermission().then((granted) => {
+    if (granted) {
+      return;
+    }
+
+    dispatch(locationSetHeadingSource('gps'));
+
+    dispatch(
+      toastsAdd({
+        id: 'main.compassPermissionDenied',
+        messageKey: 'main.compassPermissionDenied',
+        style: 'warning',
+        timeout: 5000,
+      }),
+    );
+  });
+}

--- a/src/features/location/hooks/useHeading.ts
+++ b/src/features/location/hooks/useHeading.ts
@@ -1,0 +1,342 @@
+import { toastsAdd } from '@features/toasts/model/actions.js';
+import { useAppSelector } from '@shared/hooks/useAppSelector.js';
+import { useEffect, useRef, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import {
+  type CompassReading,
+  isCompassPermissionRequired,
+  isCompassSupported,
+  subscribeCompass,
+} from '../compass.js';
+
+export type Heading = {
+  /** Degrees clockwise from north. */
+  value: number;
+  /** Cone half-angle in degrees, widening as the source gets less certain. */
+  spread: number;
+};
+
+type Source = 'compass' | 'gps';
+
+/** How often the smoothed heading is pushed to React; readings arrive far faster. */
+const TICK_MS = 100;
+
+/**
+ * A compass that went quiet (sensor wedged, permission revoked) must not freeze
+ * the beam. Generous, because a live sensor streams continuously whether or not
+ * the device moves — going quiet at all means the stream died, not that the
+ * user stood still. (Chrome's DevTools emulation is the exception: it emits
+ * only on change, so a static slider looks dead here.)
+ */
+const COMPASS_STALE_MS = 10_000;
+
+const COMPASS_MAX_ACCURACY = 30;
+
+/** Below this the GPS course is noise, whatever the fix claims. */
+const GPS_MIN_SPEED = 1;
+
+/**
+ * The course needs ageing out for the same reason the compass does. On signal
+ * loss `locateProcessor` deliberately keeps the watch running and the last fix
+ * standing, so without this the beam would keep pointing confidently the way
+ * the user was last heading while they turned around in a tunnel.
+ */
+const GPS_STALE_MS = 20_000;
+
+/** Only above this is a compass/GPS disagreement more likely bad data than crabbing. */
+const CROSS_CHECK_MIN_SPEED = 3;
+
+const CROSS_CHECK_MAX_DIFF = 60;
+
+const CROSS_CHECK_MS = 4000;
+
+/**
+ * A compass is only distrusted on evidence, which needs brisk movement to
+ * gather. Expire the verdict so one bad stretch (a car door, a pylon) does not
+ * suppress the compass for the rest of the session; a still-bad one is caught
+ * again within `CROSS_CHECK_MS` of the next chance to look.
+ */
+const DISTRUST_TTL_MS = 60_000;
+
+/** Hysteresis, so pausing at a junction does not flap the beam between sources. */
+const SWITCH_DELAY_MS = 1000;
+
+const SMOOTHING = 0.3;
+
+const MIN_CHANGE_DEG = 1;
+
+/**
+ * Devices without a magnetometer stay silent; say so rather than look broken.
+ *
+ * Where a grant is prompted for, the subscription starts while the dialog is
+ * still open, so the window has to outlast a human reading it — warning early
+ * would both lie and burn `compassWarned` for the session. That costs nothing
+ * there: a device offering the iOS permission has a magnetometer behind it, so
+ * the warning is near-unreachable anyway. Elsewhere nothing blocks the first
+ * reading, and the missing-sensor case is real, so answer quickly.
+ */
+const NO_READING_MS = isCompassPermissionRequired() ? 30_000 : 3000;
+
+const SPREAD_GPS = 45;
+
+const SPREAD_COMPASS_UNKNOWN = 30;
+
+let compassWarned = false;
+
+/** Signed difference `a - b` folded into `[-180, 180)`. */
+function angleDiff(a: number, b: number): number {
+  return ((a - b + 540) % 360) - 180;
+}
+
+/**
+ * The heading to draw for the current position, fused from the two sources that
+ * measure different things: the magnetometer (where the device points, works
+ * standing still, magnetically fragile) and the GPS course over ground (where
+ * the user moves, only while moving, rock solid). The compass wins when trusted
+ * — it is smooth and works at a standstill — with the course as fallback.
+ */
+export function useHeading(): Heading | null {
+  const dispatch = useDispatch();
+
+  const headingSource = useAppSelector(
+    (state) => state.locationSettings.headingSource,
+  );
+
+  const location = useAppSelector((state) => state.location.location);
+
+  const locate = useAppSelector((state) => state.location.locate);
+
+  const [heading, setHeading] = useState<Heading | null>(null);
+
+  const gpsRef = useRef(location);
+
+  gpsRef.current = location;
+
+  const compassRef = useRef<CompassReading | null>(null);
+
+  // Tracked apart from `compassRef`, which `onVisibility` clears: backgrounding
+  // the app near the deadline would otherwise read as "sensor never spoke" and
+  // latch `compassWarned`, muting a genuine failure later in the session.
+  const sawReadingRef = useRef(false);
+
+  const distrustRef = useRef({ since: 0, at: 0, distrusted: false });
+
+  // `pending` is nullable as a whole rather than carrying a nullable source in
+  // flat fields: losing the heading is itself a `wanted` of `null`, which a
+  // `pending: null` sentinel could not be told apart from "nothing pending".
+  const sourceRef = useRef<{
+    current: Source | null;
+    pending: { source: Source | null; since: number } | null;
+  }>({ current: null, pending: null });
+
+  const smoothRef = useRef<{ sin: number; cos: number } | null>(null);
+
+  const compassOn =
+    locate && headingSource === 'compass' && isCompassSupported();
+
+  const on = locate && headingSource !== 'none';
+
+  useEffect(() => {
+    if (!compassOn) {
+      compassRef.current = null;
+
+      return;
+    }
+
+    sawReadingRef.current = false;
+
+    const unsubscribe = subscribeCompass((reading) => {
+      compassRef.current = reading;
+
+      sawReadingRef.current = true;
+    });
+
+    // Events legitimately stop while backgrounded, and the longer staleness
+    // window would otherwise let a return show a heading minutes out of date.
+    const onVisibility = () => {
+      if (document.hidden) {
+        compassRef.current = null;
+      }
+    };
+
+    document.addEventListener('visibilitychange', onVisibility);
+
+    const timeout = setTimeout(() => {
+      if (!sawReadingRef.current && !compassWarned) {
+        compassWarned = true;
+
+        dispatch(
+          toastsAdd({
+            id: 'main.compassUnavailable',
+            messageKey: 'main.compassUnavailable',
+            style: 'warning',
+            timeout: 5000,
+          }),
+        );
+      }
+    }, NO_READING_MS);
+
+    return () => {
+      unsubscribe();
+
+      clearTimeout(timeout);
+
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, [compassOn, dispatch]);
+
+  useEffect(() => {
+    if (!on) {
+      setHeading(null);
+
+      smoothRef.current = null;
+
+      sourceRef.current = { current: null, pending: null };
+
+      // A `since` surviving a stop would let the next session's first
+      // disagreeing sample read as having already outlasted `CROSS_CHECK_MS`.
+      distrustRef.current = { since: 0, at: 0, distrusted: false };
+
+      return;
+    }
+
+    const interval = setInterval(() => {
+      const now = performance.now();
+
+      const compass =
+        compassOn &&
+        compassRef.current &&
+        now - compassRef.current.at < COMPASS_STALE_MS
+          ? compassRef.current
+          : null;
+
+      const gps =
+        gpsRef.current && Date.now() - gpsRef.current.at < GPS_STALE_MS
+          ? gpsRef.current
+          : null;
+
+      const gpsHeading =
+        gps &&
+        gps.heading !== null &&
+        gps.speed !== null &&
+        gps.speed > GPS_MIN_SPEED
+          ? gps.heading
+          : null;
+
+      // The only way to catch a magnetometer thrown off by a car door or a
+      // laptop: while moving briskly the two sources must roughly agree.
+      const distrust = distrustRef.current;
+
+      if (
+        compass &&
+        gpsHeading !== null &&
+        gps &&
+        gps.speed !== null &&
+        gps.speed > CROSS_CHECK_MIN_SPEED
+      ) {
+        if (
+          Math.abs(angleDiff(compass.heading, gpsHeading)) >
+          CROSS_CHECK_MAX_DIFF
+        ) {
+          distrust.since ||= now;
+
+          distrust.distrusted = now - distrust.since > CROSS_CHECK_MS;
+
+          distrust.at = now;
+        } else {
+          distrust.since = 0;
+
+          distrust.distrusted = false;
+        }
+      } else {
+        // No way to compare right now, so part-gathered evidence goes stale:
+        // keeping `since` would let one disagreeing sample minutes later read as
+        // having already outlasted `CROSS_CHECK_MS` and distrust instantly.
+        distrust.since = 0;
+
+        if (distrust.distrusted && now - distrust.at > DISTRUST_TTL_MS) {
+          distrust.distrusted = false;
+        }
+      }
+
+      const compassOk =
+        compass &&
+        !distrust.distrusted &&
+        (compass.accuracy === null || compass.accuracy <= COMPASS_MAX_ACCURACY);
+
+      const wanted: Source | null = compassOk
+        ? 'compass'
+        : gpsHeading === null
+          ? null
+          : 'gps';
+
+      const src = sourceRef.current;
+
+      if (wanted === src.current) {
+        src.pending = null;
+      } else if (src.current === null) {
+        // nothing on screen yet, so there is no flapping to damp
+        src.current = wanted;
+
+        src.pending = null;
+      } else if (src.pending?.source !== wanted) {
+        src.pending = { source: wanted, since: now };
+      } else if (now - src.pending.since > SWITCH_DELAY_MS) {
+        src.current = wanted;
+
+        src.pending = null;
+      }
+
+      if (src.current === null) {
+        smoothRef.current = null;
+
+        setHeading((prev) => (prev === null ? prev : null));
+
+        return;
+      }
+
+      const target =
+        src.current === 'compass' ? (compass?.heading ?? null) : gpsHeading;
+
+      if (target === null) {
+        return;
+      }
+
+      const rad = (target * Math.PI) / 180;
+
+      const smooth = smoothRef.current;
+
+      // Interpolate on the circle; averaging degrees whips the beam around the
+      // 359°→0° wrap.
+      smoothRef.current = smooth
+        ? {
+            sin: smooth.sin + (Math.sin(rad) - smooth.sin) * SMOOTHING,
+            cos: smooth.cos + (Math.cos(rad) - smooth.cos) * SMOOTHING,
+          }
+        : { sin: Math.sin(rad), cos: Math.cos(rad) };
+
+      const value =
+        (Math.atan2(smoothRef.current.sin, smoothRef.current.cos) * 180) /
+        Math.PI;
+
+      const spread =
+        src.current === 'gps'
+          ? SPREAD_GPS
+          : (compass?.accuracy ?? SPREAD_COMPASS_UNKNOWN);
+
+      setHeading((prev) =>
+        prev &&
+        Math.abs(angleDiff(prev.value, value)) < MIN_CHANGE_DEG &&
+        prev.spread === spread
+          ? prev
+          : { value: (value + 360) % 360, spread },
+      );
+    }, TICK_MS);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [on, compassOn]);
+
+  return heading;
+}

--- a/src/features/location/model/actions.ts
+++ b/src/features/location/model/actions.ts
@@ -1,9 +1,20 @@
 import { createAction } from '@reduxjs/toolkit';
+import type { HeadingSource } from './settingsReducer.js';
 
 export const setLocation = createAction<{
   lat: number;
   lon: number;
   accuracy: number;
+  /** Course over ground in degrees clockwise from true north; `null` when unknown. */
+  heading: number | null;
+  /** Ground speed in m/s; `null` when unknown. */
+  speed: number | null;
+  /** When the fix was taken, epoch ms. */
+  at: number;
 }>('SET_LOCATION');
 
 export const toggleLocate = createAction<boolean | undefined>('LOCATE');
+
+export const locationSetHeadingSource = createAction<HeadingSource>(
+  'LOCATION_SET_HEADING_SOURCE',
+);

--- a/src/features/location/model/locateProcessor.ts
+++ b/src/features/location/model/locateProcessor.ts
@@ -25,19 +25,39 @@ export const locateProcessor: Processor = {
       const mySession = ++session;
 
       const applyFix = ({
-        latitude,
-        longitude,
-        accuracy,
-      }: GeolocationCoordinates) => {
+        coords: { latitude, longitude, accuracy, heading, speed },
+        timestamp,
+      }: GeolocationPosition) => {
         if (mySession !== session) {
           return;
         }
+
+        // The phase-1 fix may be up to `maximumAge` old, so the age the platform
+        // reports is kept rather than stamped as fresh. `null` means it cannot
+        // be trusted — a host reporting a monotonic clock instead of the epoch
+        // the spec asks for — in which case the course is dropped instead of
+        // being passed off as current, since its age is what makes it usable.
+        const at =
+          Number.isFinite(timestamp) &&
+          Math.abs(Date.now() - timestamp) < 86_400_000
+            ? timestamp
+            : null;
 
         dispatch(
           setLocation({
             lat: latitude,
             lon: longitude,
             accuracy,
+            // NaN slips through some implementations where the spec asks for null
+            heading:
+              at === null || heading === null || Number.isNaN(heading)
+                ? null
+                : heading,
+            speed:
+              at === null || speed === null || Number.isNaN(speed)
+                ? null
+                : speed,
+            at: at ?? Date.now(),
           }),
         );
 
@@ -63,9 +83,9 @@ export const locateProcessor: Processor = {
       // phase 1: quick coarse fix so the marker appears immediately; ignored if
       // the accurate watch already delivered a fix
       window.navigator.geolocation?.getCurrentPosition(
-        ({ coords }) => {
+        (position) => {
           if (!getState().location.location) {
-            applyFix(coords);
+            applyFix(position);
           }
         },
         () => {},
@@ -74,8 +94,8 @@ export const locateProcessor: Processor = {
 
       // phase 2: accurate continuous tracking
       watch = window.navigator.geolocation?.watchPosition(
-        ({ coords }) => {
-          applyFix(coords);
+        (position) => {
+          applyFix(position);
         },
         (err) => {
           if (err.code === err.PERMISSION_DENIED) {

--- a/src/features/location/model/locateProcessor.ts
+++ b/src/features/location/model/locateProcessor.ts
@@ -94,9 +94,7 @@ export const locateProcessor: Processor = {
 
       // phase 2: accurate continuous tracking
       watch = window.navigator.geolocation?.watchPosition(
-        (position) => {
-          applyFix(position);
-        },
+        applyFix,
         (err) => {
           if (err.code === err.PERMISSION_DENIED) {
             dispatch(toggleLocate(false));
@@ -117,7 +115,7 @@ export const locateProcessor: Processor = {
         },
         { enableHighAccuracy: true, maximumAge: 0, timeout: 30_000 },
       );
-    } else if (window.navigator.geolocation && typeof watch === 'number') {
+    } else if (window.navigator.geolocation && watch !== undefined) {
       session++;
 
       dispatch(mapRefocus({ gpsTracked: false }));

--- a/src/features/location/model/reducer.ts
+++ b/src/features/location/model/reducer.ts
@@ -4,6 +4,12 @@ import { setLocation, toggleLocate } from './actions.js';
 
 interface GpsLocation extends LatLon {
   accuracy: number;
+  /** Course over ground in degrees clockwise from true north; `null` when unknown. */
+  heading: number | null;
+  /** Ground speed in m/s; `null` when unknown. */
+  speed: number | null;
+  /** When the fix was taken, epoch ms. */
+  at: number;
 }
 
 export interface LocationState {
@@ -23,6 +29,9 @@ export const locationReducer = createReducer(locationInitialState, (builder) =>
         lat: action.payload.lat,
         lon: action.payload.lon,
         accuracy: action.payload.accuracy,
+        heading: action.payload.heading,
+        speed: action.payload.speed,
+        at: action.payload.at,
       };
     })
     .addCase(toggleLocate, (state, action) => {

--- a/src/features/location/model/settingsReducer.ts
+++ b/src/features/location/model/settingsReducer.ts
@@ -1,0 +1,47 @@
+import { createReducer } from '@reduxjs/toolkit';
+import z from 'zod';
+import { isCompassPermissionRequired, isCompassSupported } from '../compass.js';
+import { locationSetHeadingSource } from './actions.js';
+
+/**
+ * Where the heading beam on the located position comes from:
+ *
+ * - `none` — no beam at all.
+ * - `gps` — course over ground, which the fix carries for free but only while
+ *   the user actually moves.
+ * - `compass` — the device magnetometer, which also works standing still, but
+ *   needs a permission grant on iOS and varies wildly in quality. Falls back to
+ *   the course when the compass is missing or contradicts it.
+ */
+export const HeadingSourceSchema = z.enum(['none', 'gps', 'compass']);
+
+export type HeadingSource = z.infer<typeof HeadingSourceSchema>;
+
+/**
+ * Persisted locating preferences. Separate from the transient `location` slice,
+ * which `toggleLocate` resets on every toggle.
+ */
+export interface LocationSettingsState {
+  headingSource: HeadingSource;
+}
+
+/**
+ * The compass is only worth withholding where turning it on costs the user a
+ * permission dialog — on iOS, where an unexplained prompt at an arbitrary
+ * moment mostly earns a refusal. Everywhere else it is strictly better than the
+ * course over ground (it works standing still, and updates far more smoothly),
+ * so it is the default and the magnetometer costs nothing next to the GPS that
+ * is already running whenever the beam is drawn.
+ */
+export const locationSettingsInitialState: LocationSettingsState = {
+  headingSource:
+    isCompassSupported() && !isCompassPermissionRequired() ? 'compass' : 'gps',
+};
+
+export const locationSettingsReducer = createReducer(
+  locationSettingsInitialState,
+  (builder) =>
+    builder.addCase(locationSetHeadingSource, (state, action) => {
+      state.headingSource = action.payload;
+    }),
+);

--- a/src/features/mapSettings/components/MapPreferencesModal.tsx
+++ b/src/features/mapSettings/components/MapPreferencesModal.tsx
@@ -1,6 +1,13 @@
 import { useDocumentTitle } from '@app/hooks/useDocumentTitle.js';
-import { saveSettings, setActiveModal } from '@app/store/actions.js';
+import {
+  locationSetHeadingSource,
+  saveSettings,
+  setActiveModal,
+} from '@app/store/actions.js';
 import { useMessages } from '@features/l10n/l10nInjector.js';
+import { isCompassSupported } from '@features/location/compass.js';
+import { ensureCompassPermission } from '@features/location/ensureCompassPermission.js';
+import { locationSettingsInitialState } from '@features/location/model/settingsReducer.js';
 import { mapSetLocalPrefs } from '@features/map/model/actions.js';
 import { mapInitialState } from '@features/map/model/reducer.js';
 import { ResetToDefaultsButton } from '@shared/components/ResetToDefaultsButton.js';
@@ -48,6 +55,12 @@ export default function MapPreferencesModal({ show }: Props): ReactElement {
 
   const [featureScale, setFeatureScale] = useState(initialFeatureScale);
 
+  const initialHeadingSource = useAppSelector(
+    (state) => state.locationSettings.headingSource,
+  );
+
+  const [headingSource, setHeadingSource] = useState(initialHeadingSource);
+
   const invalidMaxZoom = isInvalidInt(maxZoom, false, 0, 99);
 
   useDocumentTitle(show ? m?.mapLayers.preferences : undefined);
@@ -68,6 +81,8 @@ export default function MapPreferencesModal({ show }: Props): ReactElement {
     );
 
     setFeatureScale(String(mapInitialState.featureScale));
+
+    setHeadingSource(locationSettingsInitialState.headingSource);
   }, []);
 
   const handleSubmit = (e: SubmitEvent) => {
@@ -94,6 +109,17 @@ export default function MapPreferencesModal({ show }: Props): ReactElement {
       );
     }
 
+    if (headingSource !== initialHeadingSource) {
+      dispatch(locationSetHeadingSource(headingSource));
+
+      // Prompt while the reason for it is still on screen. Reviving an
+      // unchanged stored choice cannot happen here — Save is disabled when the
+      // form is clean — so the locate button carries that case instead.
+      if (headingSource === 'compass') {
+        ensureCompassPermission(dispatch);
+      }
+    }
+
     if (Object.keys(settings).length > 0) {
       // saveSettingsProcessor closes the modal on success;
       // dispatching setActiveModal(null) here would cancel its PATCH.
@@ -113,7 +139,8 @@ export default function MapPreferencesModal({ show }: Props): ReactElement {
   const dirty =
     maxZoom !== initialMaxZoom ||
     resolutionScale !== initialResolutionScale ||
-    featureScale !== initialFeatureScale;
+    featureScale !== initialFeatureScale ||
+    headingSource !== initialHeadingSource;
 
   const atDefault =
     maxZoom === String(mapInitialState.maxZoom) &&
@@ -121,7 +148,8 @@ export default function MapPreferencesModal({ show }: Props): ReactElement {
       (mapInitialState.resolutionScale === null
         ? ''
         : String(mapInitialState.resolutionScale)) &&
-    featureScale === String(mapInitialState.featureScale);
+    featureScale === String(mapInitialState.featureScale) &&
+    headingSource === locationSettingsInitialState.headingSource;
 
   return (
     <Modal
@@ -208,6 +236,44 @@ export default function MapPreferencesModal({ show }: Props): ReactElement {
 
             <Form.Text muted className="d-block">
               {m?.mapLayers.featureScaleHelp}
+            </Form.Text>
+          </Form.Group>
+
+          <Form.Group className="mt-3">
+            <Form.Label className="d-block">{m?.main.headingSource}</Form.Label>
+
+            <ToggleButtonGroup
+              type="radio"
+              name="headingSource"
+              value={headingSource}
+              onChange={setHeadingSource}
+            >
+              {(['none', 'gps', 'compass'] as const)
+                // No point offering the magnetometer where there is none —
+                // unless it is the stored choice, since dropping the selected
+                // value would leave the group with nothing selected. Keyed on
+                // the stored value, not the live one, or picking another source
+                // would make the option vanish with no way back to it.
+                .filter(
+                  (source) =>
+                    source !== 'compass' ||
+                    isCompassSupported() ||
+                    initialHeadingSource === 'compass',
+                )
+                .map((source) => (
+                  <ToggleButton
+                    key={source}
+                    id={`hs-${source}`}
+                    value={source}
+                    variant="outline-primary"
+                  >
+                    {m?.main.headingSources[source]}
+                  </ToggleButton>
+                ))}
+            </ToggleButtonGroup>
+
+            <Form.Text muted className="d-block">
+              {m?.main.headingSourceHelp}
             </Form.Text>
           </Form.Group>
         </Modal.Body>

--- a/src/static/llms.txt
+++ b/src/static/llms.txt
@@ -510,6 +510,8 @@ The toolbar also contains the following buttons:
 - find me (locate me by the browser's geolocation API)
 - toggle fullscreen
 
+The located position is drawn as a crosshair with an accuracy circle, plus a direction beam that widens as the heading gets less certain. Its source is chosen by the **Direction indicator** preference (see Preferences below): *Hidden*, *Direction of travel* (GPS course, shown only while moving), or *Device compass* (also works standing still; offered only on devices with orientation sensors). The compass is the default wherever it needs no permission; on iOS, which prompts for it, the default is direction of travel.
+
 There is also a button with three vertical dots that opens a menu listing additional maps, a "Filter maps" box, and a "Show all maps" item. The same menu includes a "Manage maps" item (described below).
 
 ### Manage maps
@@ -545,7 +547,8 @@ Manage user-defined map layers — a list with edit/delete actions and an **Add 
 - **Max zoom** — global maximum zoom level
 - **Resolution scale** — simulates display pixel density and affects which tile variant is fetched (Auto by default)
 - **Feature size** — enlarges rendered labels and lines (no effect on satellite, shading, WMS, or vector (MapLibre) layers)
-- **Reset to default** — fills this modal's fields (max zoom, resolution scale, feature size) with their defaults; apply with Save or close without saving
+- **Direction indicator** — source of the direction beam on the located position: *Hidden*, *Direction of travel* (GPS course over ground, visible only while moving) or *Device compass* (magnetometer, works standing still, offered only where orientation sensors exist). Defaults to the compass except on iOS, where enabling it costs a permission prompt, so direction of travel is the default there
+- **Reset to default** — fills this modal's fields (max zoom, resolution scale, feature size, direction indicator) with their defaults; apply with Save or close without saving
 
 Modals that edit a persisted default style or settings (Map preferences, Configure layers, drawing **Default properties**, objects **Marker style**, track-viewer **Default style**, **Search result style**) also carry a **Reset to default** button that refills the form with default values (applied with Save, not immediately).
 

--- a/src/translations/cs.template.tsx
+++ b/src/translations/cs.template.tsx
@@ -190,6 +190,17 @@ const messages: DeepPartialWithRequiredObjects<Messages> = {
     closeTool: 'Zavřít nástroj',
     locateMe: 'Kde jsem?',
     locationError: 'Nepodařilo se získat pozici.',
+    headingSource: 'Ukazatel směru',
+    headingSources: {
+      none: 'Skrytý',
+      gps: 'Směr pohybu',
+      compass: 'Kompas zařízení',
+    },
+    headingSourceHelp:
+      'Směr pohybu pochází z GPS a zobrazuje se pouze při pohybu. Kompas zařízení funguje i vestoje, vyžaduje však oprávnění a může být nepřesný.',
+    compassPermissionDenied: 'Přístup ke kompasu byl zamítnut.',
+    compassUnavailable:
+      'Žádná data z kompasu. Vaše zařízení ho nemusí mít, nebo je přístup k němu zablokován.',
     zoomIn: 'Přiblížit mapu',
     zoomOut: 'Oddálit mapu',
     devInfo: () => (

--- a/src/translations/de.template.tsx
+++ b/src/translations/de.template.tsx
@@ -192,6 +192,17 @@ const messages: DeepPartialWithRequiredObjects<Messages> = {
     closeTool: 'Werkzeug schließen',
     locateMe: 'Standort ermitteln',
     locationError: 'Fehler beim Abrufen des Standorts.',
+    headingSource: 'Richtungsanzeige',
+    headingSources: {
+      none: 'Ausgeblendet',
+      gps: 'Bewegungsrichtung',
+      compass: 'Gerätekompass',
+    },
+    headingSourceHelp:
+      'Die Bewegungsrichtung stammt vom GPS und erscheint nur in Bewegung. Der Gerätekompass funktioniert auch im Stand, benötigt aber eine Berechtigung und kann ungenau sein.',
+    compassPermissionDenied: 'Zugriff auf den Kompass wurde verweigert.',
+    compassUnavailable:
+      'Keine Kompassdaten. Ihr Gerät hat möglicherweise keinen Kompass, oder der Zugriff darauf ist blockiert.',
     zoomIn: 'Vergrößern',
     zoomOut: 'Verkleinern',
     devInfo: () => (

--- a/src/translations/en.messages.tsx
+++ b/src/translations/en.messages.tsx
@@ -184,6 +184,17 @@ const messages: Messages = {
     closeTool: 'Close tool',
     locateMe: 'Locate me',
     locationError: 'Error getting location.',
+    headingSource: 'Direction indicator',
+    headingSources: {
+      none: 'Hidden',
+      gps: 'Direction of travel',
+      compass: 'Device compass',
+    },
+    headingSourceHelp:
+      'Direction of travel comes from the GPS and only shows while you are moving. The device compass works while standing still too, but needs permission and can be inaccurate.',
+    compassPermissionDenied: 'Access to the compass was denied.',
+    compassUnavailable:
+      'No compass data. Your device may have no compass, or access to it is blocked.',
     zoomIn: 'Zoom in',
     zoomOut: 'Zoom out',
     devInfo: () => (

--- a/src/translations/fr.template.tsx
+++ b/src/translations/fr.template.tsx
@@ -201,6 +201,17 @@ const messages: DeepPartialWithRequiredObjects<Messages> = {
     closeTool: 'Fermer l’outil',
     locateMe: 'Me localiser',
     locationError: 'Erreur lors de l’obtention de la position.',
+    headingSource: 'Indicateur de direction',
+    headingSources: {
+      none: 'Masqué',
+      gps: 'Direction du déplacement',
+      compass: 'Boussole de l’appareil',
+    },
+    headingSourceHelp:
+      'La direction du déplacement provient du GPS et n’apparaît qu’en mouvement. La boussole de l’appareil fonctionne aussi à l’arrêt, mais nécessite une autorisation et peut être imprécise.',
+    compassPermissionDenied: 'L’accès à la boussole a été refusé.',
+    compassUnavailable:
+      'Aucune donnée de boussole. Votre appareil n’en a peut-être pas, ou l’accès est bloqué.',
     zoomIn: 'Zoom avant',
     zoomOut: 'Zoom arrière',
     copyright: 'Droits d’auteur',

--- a/src/translations/hu.template.tsx
+++ b/src/translations/hu.template.tsx
@@ -191,6 +191,17 @@ const messages: DeepPartialWithRequiredObjects<Messages> = {
     closeTool: 'Eszköz bezárása',
     locateMe: 'Saját pozícióm',
     locationError: 'Nem sikerült megtalálni a helyzetét.',
+    headingSource: 'Irányjelző',
+    headingSources: {
+      none: 'Rejtett',
+      gps: 'Haladási irány',
+      compass: 'Az eszköz iránytűje',
+    },
+    headingSourceHelp:
+      'A haladási irány a GPS-ből származik, és csak mozgás közben látszik. Az eszköz iránytűje állva is működik, de engedélyt igényel, és pontatlan lehet.',
+    compassPermissionDenied: 'Az iránytűhöz való hozzáférés megtagadva.',
+    compassUnavailable:
+      'Nincsenek iránytűadatok. Lehet, hogy az eszközén nincs iránytű, vagy a hozzáférés blokkolva van.',
     zoomIn: 'Nagyítás',
     zoomOut: 'Kicsinyítés',
 

--- a/src/translations/it.template.tsx
+++ b/src/translations/it.template.tsx
@@ -196,6 +196,17 @@ const messages: DeepPartialWithRequiredObjects<Messages> = {
     closeTool: 'Chiudi lo strumento',
     locateMe: 'Localizzami',
     locationError: 'Errore nel determinare la locazione.',
+    headingSource: 'Indicatore di direzione',
+    headingSources: {
+      none: 'Nascosto',
+      gps: 'Direzione di marcia',
+      compass: 'Bussola del dispositivo',
+    },
+    headingSourceHelp:
+      'La direzione di marcia proviene dal GPS e appare solo mentre ti muovi. La bussola del dispositivo funziona anche da fermo, ma richiede un permesso e può essere imprecisa.',
+    compassPermissionDenied: 'Accesso alla bussola negato.',
+    compassUnavailable:
+      'Nessun dato dalla bussola. Il dispositivo potrebbe non averla, oppure l’accesso è bloccato.',
     zoomIn: 'Zoom avanti',
     zoomOut: 'Zoom indietro',
     devInfo: () => (

--- a/src/translations/messagesInterface.ts
+++ b/src/translations/messagesInterface.ts
@@ -149,6 +149,11 @@ export type Messages = {
     closeTool: string;
     locateMe: string;
     locationError: string;
+    headingSource: string;
+    headingSources: Record<'none' | 'gps' | 'compass', string>;
+    headingSourceHelp: string;
+    compassPermissionDenied: string;
+    compassUnavailable: string;
     zoomIn: string;
     zoomOut: string;
     devInfo: () => JSX.Element;

--- a/src/translations/pl.template.tsx
+++ b/src/translations/pl.template.tsx
@@ -184,6 +184,17 @@ const messages: DeepPartialWithRequiredObjects<Messages> = {
     closeTool: 'Zamknij narzędzie',
     locateMe: 'Pokaż moją pozycję',
     locationError: 'Błąd pobierania pozycji.',
+    headingSource: 'Wskaźnik kierunku',
+    headingSources: {
+      none: 'Ukryty',
+      gps: 'Kierunek ruchu',
+      compass: 'Kompas urządzenia',
+    },
+    headingSourceHelp:
+      'Kierunek ruchu pochodzi z GPS i jest widoczny tylko podczas ruchu. Kompas urządzenia działa też w bezruchu, ale wymaga zgody i bywa niedokładny.',
+    compassPermissionDenied: 'Odmówiono dostępu do kompasu.',
+    compassUnavailable:
+      'Brak danych kompasu. Twoje urządzenie może go nie mieć lub dostęp jest zablokowany.',
     zoomIn: 'Powiększ',
     zoomOut: 'Pomniejsz',
     devInfo: () => (

--- a/src/translations/sk.template.tsx
+++ b/src/translations/sk.template.tsx
@@ -189,6 +189,17 @@ const messages: DeepPartialWithRequiredObjects<Messages> = {
     closeTool: 'Zavrieť nástroj',
     locateMe: 'Kde som?',
     locationError: 'Nepodarilo sa získať pozíciu.',
+    headingSource: 'Ukazovateľ smeru',
+    headingSources: {
+      none: 'Skrytý',
+      gps: 'Smer pohybu',
+      compass: 'Kompas zariadenia',
+    },
+    headingSourceHelp:
+      'Smer pohybu pochádza z GPS a zobrazuje sa iba počas pohybu. Kompas zariadenia funguje aj v stoji, vyžaduje však povolenie a môže byť nepresný.',
+    compassPermissionDenied: 'Prístup ku kompasu bol zamietnutý.',
+    compassUnavailable:
+      'Žiadne údaje z kompasu. Vaše zariadenie ho nemusí mať, alebo je prístup k nemu zablokovaný.',
     zoomIn: 'Priblížiť mapu',
     zoomOut: 'Oddialiť mapu',
     devInfo: () => (

--- a/src/translations/sl.template.tsx
+++ b/src/translations/sl.template.tsx
@@ -189,6 +189,17 @@ const messages: DeepPartialWithRequiredObjects<Messages> = {
     closeTool: 'Zapri orodje',
     locateMe: 'Kje sem?',
     locationError: 'Napaka pri pridobivanju lokacije.',
+    headingSource: 'Kazalnik smeri',
+    headingSources: {
+      none: 'Skrit',
+      gps: 'Smer gibanja',
+      compass: 'Kompas naprave',
+    },
+    headingSourceHelp:
+      'Smer gibanja izhaja iz GPS in je vidna le med gibanjem. Kompas naprave deluje tudi na mestu, a zahteva dovoljenje in je lahko nenatančen.',
+    compassPermissionDenied: 'Dostop do kompasa je bil zavrnjen.',
+    compassUnavailable:
+      'Ni podatkov kompasa. Vaša naprava ga morda nima ali pa je dostop do njega blokiran.',
     zoomIn: 'Približaj',
     zoomOut: 'Oddalji',
     devInfo: () => (


### PR DESCRIPTION
Draws a fading wedge under the located position pointing where the user faces. Its width tracks how certain the heading is — narrow for a well-calibrated compass, broad when falling back to the GPS course.

The crosshair and accuracy circle are unchanged in shape: heading drops in and out (the course vanishes when you stop, compass events stutter), and a marker that morphs between two forms is visually noisy, so only the beam fades.

## Two sources, measuring different things

| Source | Standing still | Permission | Character |
|---|---|---|---|
| `coords.heading` — course over ground | no | none, free with every fix | true north, reliable while moving, ~1 Hz |
| `DeviceOrientationEvent` — magnetometer | yes | prompted on iOS 13+ | smooth at ~60 Hz, magnetically fragile |

They disagree legitimately — walking sideways, sitting backwards on a train — so the compass wins where trusted (`useHeading.ts`), with the course as fallback. Guards on the fusion:

- staleness on both sources, so a dead stream or a fix frozen by signal loss stops the beam rather than freezing it
- hysteresis on the source switch, so pausing at a junction doesn't flap the beam
- a cross-check that distrusts a compass persistently disagreeing with the course above 3 m/s — the only way to catch a magnetometer thrown off by a car door — expiring after a minute so one bad stretch doesn't suppress it for the session
- circular (sin/cos) smoothing, since averaging degrees whips the beam around the 359°→0° wrap

`compass.ts` normalizes the two incompatible browser APIs: iOS `webkitCompassHeading` and the W3C absolute Euler angles. The latter go through a tilt-compensated blend of the screen-up vector and the screen normal, each degenerate where the other works, so the reading stays right whether the phone is flat or held upright, and in landscape.

## Preference, not a toolbar control

**Map preferences → Direction indicator**: Hidden / Direction of travel / Device compass. A permanently visible toolbar control would cost more space than one setting is worth, and only a modal has room for a source choice.

Defaults to the compass wherever enabling it needs no permission, and to the course on iOS, where an unexplained prompt at an arbitrary moment mostly earns a refusal. The iOS grant doesn't survive a reload while the preference does, so it is re-requested from the locate button — the earliest gesture in a session meaning "locate me".

## Also

Fixes the accuracy circle, which drew `accuracy / 2`. `coords.accuracy` is already the radius of the 95%-confidence circle, so it was claiming twice the precision of the actual fix.

## Testing

`tsc --noEmit`, `biome check` and all 324 tests pass. Exercised in Chrome via DevTools sensor emulation; dev builds accept relative orientation events so the panel can drive it without a phone (`ACCEPT_RELATIVE`, keyed off `DEPLOYMENT` the same way `rspack.config.ts` decides on a production build).

Not verified on hardware: the iOS permission flow, and whether `webkitCompassHeading` is true- or magnetic-north referenced. Worth a pass on a real iPhone before release.

## Follow-ups, deliberately out of scope

- swapping the crosshair for a dot, to be designed together with a planned bearing/distance line whose other end wants the crosshair
- ageing out the whole location display on signal loss, not just the beam — the marker and accuracy circle still sit at the last fix, as before this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)