### PR TITLE
feat(premium): announce the price increase and win back lapsed buyers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -160,6 +160,21 @@ compute/infra or power-user limits; avoid third-party data (license risk — see
 Strava) and community content (CC-BY-SA can't be made exclusive + optics). Keep
 the free/open core intact.
 
+On 1 September 2026 the premium price rises to €15 for new customers. Nothing
+switches by itself — do all of this on the day:
+
+- set `PREMIUM_PRICE_EUR` to `15` in `src/shared/premiumPricing.ts` (leave
+  `PREMIUM_WINBACK_PRICE_EUR` at 8 — the win-back product keeps that price);
+- drop the announcement: the premium branch of `InfoBar.tsx`,
+  `usePremiumPriceIncreaseInfo`, the `priceIncrease*` messages, and the alert in
+  `PremiumActivationModal` (which then only shows the win-back offer);
+- point `POLAR_PREMIUM_RECURRING_PRODUCT_ID` and
+  `POLAR_PREMIUM_ONETIME_PRODUCT_ID` at the €15 products in the backend env;
+- in Polar, archive the €8 products except the unlisted one the win-back offer
+  (`POLAR_PREMIUM_WINBACK_PRODUCT_ID`) sells;
+- update the price in `src/documents/premium.{en,sk}.md`,
+  `src/documents/termsOfService.{en,sk}.md` and `src/static/llms.txt`.
+
 ## Elevation / track chart
 
 Feature requests are tracked as GitHub issues (label `area: elevation-chart`):

--- a/src/app/components/InfoBar.tsx
+++ b/src/app/components/InfoBar.tsx
@@ -1,10 +1,16 @@
 import { useMessages } from '@features/l10n/l10nInjector.js';
+import { usePremiumPriceIncreaseInfo } from '@features/premium/hooks/usePremiumPriceIncreaseInfo.js';
 import { useAppSelector } from '@shared/hooks/useAppSelector.js';
-import { type ReactElement, useEffect, useState } from 'react';
+import { type ReactElement, useEffect, useRef, useState } from 'react';
 import { CloseButton } from 'react-bootstrap';
 import { useDispatch } from 'react-redux';
-import { hideInfoBar } from '../store/actions.js';
+import { hideInfoBar, infoBarShown } from '../store/actions.js';
 import classes from './InfoBar.module.css';
+
+// Announcement owned by the premium feature: its text lives in the feature
+// messages, so it falls back to English in languages that haven't translated it
+// yet. It stands until removed from here — nothing expires by itself.
+const PREMIUM_PRICE_INCREASE_KEY = 'premiumPriceIncrease';
 
 export function InfoBar(): ReactElement | null {
   const m = useMessages();
@@ -15,6 +21,21 @@ export function InfoBar(): ReactElement | null {
 
   const hiddenInfoBars = useAppSelector((state) => state.main.hiddenInfoBars);
 
+  const shownInfoBars = useAppSelector((state) => state.main.shownInfoBars);
+
+  const premiumPriceIncrease = usePremiumPriceIncreaseInfo();
+
+  // A running subscription keeps its price, so the increase is not its owner's
+  // problem. Everyone else is told — including a user holding a one-time year,
+  // who can still switch to a subscription and lock the current price.
+  const grandfathered = useAppSelector((state) =>
+    Boolean(state.auth.user?.premiumSubscription),
+  );
+
+  // Frozen at mount: recording the chosen bar as shown (below) must not rotate
+  // it away mid-session.
+  const rotation = useRef(shownInfoBars).current;
+
   useEffect(() => {
     const ref = window.setInterval(
       () => setShow((s) => s + 1),
@@ -24,23 +45,38 @@ export function InfoBar(): ReactElement | null {
     return () => window.clearInterval(ref);
   }, []);
 
-  if (!m || !show) {
-    return null;
-  }
-
-  const { infoBars } = m.main;
-
   const ts = Date.now();
 
-  const key = Object.keys(infoBars).find(
-    (key) => ts - (hiddenInfoBars[key] ?? 0) > 24 * 60 * 60_000, // expire in a day
-  );
+  const infoBars = m?.main.infoBars;
 
-  if (!key) {
+  // The least recently shown bar that isn't dismissed, so that none of them
+  // starves while another one is up.
+  const key = [
+    ...Object.keys(infoBars ?? {}),
+    ...(grandfathered ? [] : [PREMIUM_PRICE_INCREASE_KEY]),
+  ]
+    .filter((key) => ts - (hiddenInfoBars[key] ?? 0) > 24 * 60 * 60_000) // dismissal expires in a day
+    .sort((a, b) => (rotation[a] ?? 0) - (rotation[b] ?? 0))[0];
+
+  useEffect(() => {
+    if (key) {
+      dispatch(infoBarShown({ key, ts: Date.now() }));
+    }
+  }, [key, dispatch]);
+
+  if (!show || !key) {
     return null;
   }
 
-  const InfoBarContent = infoBars[key]!;
+  const InfoBarContent = infoBars?.[key];
+
+  // The premium announcement is null until its messages arrive; showing the bar
+  // then would be an empty strip with a close button.
+  const content = InfoBarContent ? <InfoBarContent /> : premiumPriceIncrease;
+
+  if (!content) {
+    return null;
+  }
 
   return (
     <div className={classes.infoBar}>
@@ -52,7 +88,7 @@ export function InfoBar(): ReactElement | null {
         }}
       />
 
-      <InfoBarContent />
+      {content}
     </div>
   );
 }

--- a/src/app/store/actions.ts
+++ b/src/app/store/actions.ts
@@ -210,4 +210,10 @@ export const hideInfoBar = createAction<{
   ts: number;
 }>('HIDE_INFO_BAR');
 
+/** Records that an info bar was displayed, so that the next one gets its turn. */
+export const infoBarShown = createAction<{
+  key: string;
+  ts: number;
+}>('INFO_BAR_SHOWN');
+
 export const init = createAction('INIT');

--- a/src/app/store/middleware/statePersistingMiddleware.test.ts
+++ b/src/app/store/middleware/statePersistingMiddleware.test.ts
@@ -18,7 +18,7 @@ const premiumDate = new Date('2026-05-17T12:00:48.000Z');
 function makeState(): RootState {
   return {
     l10n: { chosenLanguage: 'sk', language: 'en' },
-    main: { hiddenInfoBars: { foo: 1 } },
+    main: { hiddenInfoBars: { foo: 1 }, shownInfoBars: { foo: 2 } },
     homeLocation: { homeLocation: { lat: 1, lon: 2 } },
     // In state but not persisted (no PERSIST entry).
     location: {
@@ -155,7 +155,7 @@ describe('statePersistingMiddleware — what gets persisted', () => {
 
     expect(saved).toEqual({
       l10n: { chosenLanguage: 'sk' },
-      main: { hiddenInfoBars: { foo: 1 } },
+      main: { hiddenInfoBars: { foo: 1 }, shownInfoBars: { foo: 2 } },
       homeLocation: { homeLocation: { lat: 1, lon: 2 } },
       cookieConsent: {
         cookieConsentResult: true,
@@ -335,6 +335,7 @@ describe('save → rehydrate round-trip', () => {
 
     expect(initial.l10n?.chosenLanguage).toBe('sk');
     expect(initial.main?.hiddenInfoBars).toEqual({ foo: 1 });
+    expect(initial.main?.shownInfoBars).toEqual({ foo: 2 });
     expect(initial.homeLocation?.homeLocation).toEqual({ lat: 1, lon: 2 });
     expect(initial.cookieConsent?.cookieConsentResult).toBe(true);
     expect(initial.objectsSettings?.selectedIcon).toBe('pin');

--- a/src/app/store/persistence.ts
+++ b/src/app/store/persistence.ts
@@ -103,6 +103,7 @@ export const PersistedHomeLocationSchema = z
 export const PersistedMainSchema = z
   .object({
     hiddenInfoBars: z.record(z.string(), z.number()),
+    shownInfoBars: z.record(z.string(), z.number()),
   })
   .partial();
 
@@ -292,7 +293,10 @@ const PERSIST: PersistEntry[] = [
     key: 'main',
     schema: PersistedMainSchema,
     initial: mainInitialState,
-    persist: (s) => ({ hiddenInfoBars: s.hiddenInfoBars }),
+    persist: (s) => ({
+      hiddenInfoBars: s.hiddenInfoBars,
+      shownInfoBars: s.shownInfoBars,
+    }),
   }),
   defineEntry({
     key: 'objectsSettings',

--- a/src/app/store/reducer.ts
+++ b/src/app/store/reducer.ts
@@ -29,6 +29,7 @@ import {
   convertToDrawing,
   deleteFeature,
   hideInfoBar,
+  infoBarShown,
   type Selection,
   selectFeature,
   setActiveModal,
@@ -49,6 +50,7 @@ export interface MainState {
   embedFeatures: string[];
   selection: Selection | null;
   hiddenInfoBars: Record<string, number>;
+  shownInfoBars: Record<string, number>;
 }
 
 export const mainInitialState: MainState = {
@@ -59,6 +61,7 @@ export const mainInitialState: MainState = {
   embedFeatures: [],
   selection: null,
   hiddenInfoBars: {},
+  shownInfoBars: {},
 };
 
 export const mainReducer = createReducer(mainInitialState, (builder) => {
@@ -182,6 +185,9 @@ export const mainReducer = createReducer(mainInitialState, (builder) => {
     })
     .addCase(hideInfoBar, (state, action) => {
       state.hiddenInfoBars[action.payload.key] = action.payload.ts;
+    })
+    .addCase(infoBarShown, (state, action) => {
+      state.shownInfoBars[action.payload.key] = action.payload.ts;
     })
     .addCase(routePlannerAddPoint, (state, action) => {
       return {

--- a/src/documents/premium.en.md
+++ b/src/documents/premium.en.md
@@ -21,7 +21,7 @@ Freemap.sk is an open web and mobile mapping application for outdoor and everyda
 
 ## Price
 
-**EUR 8 per year.** The subscription gives you one year of premium access and renews yearly unless cancelled.
+**EUR 8 per year up to 31 August 2026, EUR 15 per year from 1 September 2026.** The subscription gives you one year of premium access and renews yearly unless cancelled. A subscription started before 1 September 2026 keeps the EUR 8 price for as long as it stays active; a one-time purchase of a single year keeps it for that year only.
 
 You can manage and cancel your subscription at any time; cancellation takes effect at the end of the paid period. For details on refunds, see our [Refund Policy](#document=refundPolicy).
 

--- a/src/documents/premium.sk.md
+++ b/src/documents/premium.sk.md
@@ -19,7 +19,7 @@ Na podporu ďalšieho vývoja a pokrytie prevádzkových nákladov služby ponú
 
 ## Cena
 
-**8 EUR ročne.** Predplatné vám dáva jeden rok prémiového prístupu a obnovuje sa ročne, pokiaľ ho nezrušíte.
+**8 EUR ročne do 31. augusta 2026, 15 EUR ročne od 1. septembra 2026.** Predplatné vám dáva jeden rok prémiového prístupu a obnovuje sa ročne, pokiaľ ho nezrušíte. Predplatné aktivované pred 1. septembrom 2026 si cenu 8 EUR ponecháva, pokiaľ zostane aktívne; jednorazová platba za jeden rok platí len na daný rok.
 
 Predplatné môžete kedykoľvek spravovať a zrušiť; zrušenie nadobudne účinnosť na konci zaplateného obdobia. Podrobnosti o vrátení peňazí nájdete v [Zásadách vrátenia peňazí](#document=refundPolicy).
 

--- a/src/documents/termsOfService.en.md
+++ b/src/documents/termsOfService.en.md
@@ -55,9 +55,9 @@ The exact set of features may evolve over time. We may add, change or remove ind
 
 ## Price and billing
 
-Freemap Premium is offered as a **yearly Subscription** at the price of **EUR 8 per year** (the current price is always shown at checkout and prevails over any figure stated here). Prices are stated in euro (EUR) and include applicable value-added tax (VAT) where required; the final amount, including any VAT, is shown before You confirm Your purchase. We issue You a receipt or invoice for each payment.
+Freemap Premium is offered as a **yearly Subscription** at the price of **EUR 8 per year up to 31 August 2026 and EUR 15 per year from 1 September 2026** (the current price is always shown at checkout and prevails over any figure stated here). Prices are stated in euro (EUR) and include applicable value-added tax (VAT) where required; the final amount, including any VAT, is shown before You confirm Your purchase. We issue You a receipt or invoice for each payment.
 
-The Subscription is **auto-renewing**: it renews automatically for successive one-year periods at the then-current price, unless You cancel before the renewal date. We will charge the payment method You provided, through Our Payment Processor, at each renewal.
+The Subscription is **auto-renewing**: it renews automatically for successive one-year periods at the price of Your Subscription, unless You cancel before the renewal date. A price increase applies to new Subscriptions; Your Subscription keeps its price for as long as it stays active, and We will notify You in advance if that ever has to change. We will charge the payment method You provided, through Our Payment Processor, at each renewal.
 
 ## Payment
 

--- a/src/documents/termsOfService.sk.md
+++ b/src/documents/termsOfService.sk.md
@@ -53,9 +53,9 @@ Presný rozsah funkcií sa môže časom meniť. Jednotlivé prémiové funkcie 
 
 ## Cena a fakturácia
 
-Freemap Premium sa ponúka ako **ročné Predplatné** za cenu **8 EUR ročne** (aktuálna cena je vždy uvedená pri platbe a má prednosť pred akýmkoľvek údajom uvedeným tu). Ceny sú uvedené v eurách (EUR) a zahŕňajú príslušnú daň z pridanej hodnoty (DPH), ak sa vyžaduje; konečná suma vrátane prípadnej DPH sa zobrazí pred potvrdením Vašej objednávky. Ku každej platbe Vám vystavíme doklad alebo faktúru.
+Freemap Premium sa ponúka ako **ročné Predplatné** za cenu **8 EUR ročne do 31. augusta 2026 a 15 EUR ročne od 1. septembra 2026** (aktuálna cena je vždy uvedená pri platbe a má prednosť pred akýmkoľvek údajom uvedeným tu). Ceny sú uvedené v eurách (EUR) a zahŕňajú príslušnú daň z pridanej hodnoty (DPH), ak sa vyžaduje; konečná suma vrátane prípadnej DPH sa zobrazí pred potvrdením Vašej objednávky. Ku každej platbe Vám vystavíme doklad alebo faktúru.
 
-Predplatné sa **automaticky obnovuje**: obnovuje sa automaticky na ďalšie jednoročné obdobia za vtedy platnú cenu, pokiaľ ho nezrušíte pred dátumom obnovenia. Pri každom obnovení zaúčtujeme platbu z Vami poskytnutého platobného prostriedku prostredníctvom Nášho Spracovateľa platieb.
+Predplatné sa **automaticky obnovuje**: obnovuje sa automaticky na ďalšie jednoročné obdobia za cenu Vášho Predplatného, pokiaľ ho nezrušíte pred dátumom obnovenia. Zvýšenie ceny sa vzťahuje na nové Predplatné; Vaše Predplatné si svoju cenu ponecháva, pokiaľ zostane aktívne, a ak by sa to niekedy muselo zmeniť, vopred Vás upozorníme. Pri každom obnovení zaúčtujeme platbu z Vami poskytnutého platobného prostriedku prostredníctvom Nášho Spracovateľa platieb.
 
 ## Platba
 

--- a/src/features/auth/components/LoginModal.tsx
+++ b/src/features/auth/components/LoginModal.tsx
@@ -3,6 +3,7 @@ import { setActiveModal } from '@app/store/actions.js';
 import { useMessages } from '@features/l10n/l10nInjector.js';
 import { usePremiumMessages } from '@features/premium/translations/usePremiumMessages.js';
 import { useAppSelector } from '@shared/hooks/useAppSelector.js';
+import { PREMIUM_PRICE_EUR } from '@shared/premiumPricing.js';
 import { type ReactElement, useCallback } from 'react';
 import { Alert, Button, Modal } from 'react-bootstrap';
 import { FaExclamationTriangle, FaSignInAlt, FaTimes } from 'react-icons/fa';
@@ -36,7 +37,7 @@ export default function LoginModal({ show }: Props): ReactElement {
   const renderPremiumInfo = () =>
     purchaseOnLogin?.type === 'premium' ? (
       <Alert variant="primary">
-        {prm?.commonHeader}
+        {prm?.commonHeader(PREMIUM_PRICE_EUR)}
         {prm?.stepsForAnonymous}
       </Alert>
     ) : null;

--- a/src/features/auth/model/reducer.ts
+++ b/src/features/auth/model/reducer.ts
@@ -29,6 +29,7 @@ export const authReducer = createReducer(authInitialState, (builder) =>
         authToken: action.payload.authToken,
         roles: action.payload.roles,
         premiumExpiration: action.payload.premiumExpiration,
+        premiumSubscription: action.payload.premiumSubscription,
         authProviders: action.payload.authProviders,
         credits: action.payload.credits,
         coordinates: action.payload.coordinates,

--- a/src/features/auth/model/types.ts
+++ b/src/features/auth/model/types.ts
@@ -109,6 +109,10 @@ export const UserSchema = z.object({
   coordinates: LatLonSchema.nullable(),
   name: z.string(),
   premiumExpiration: IsoDateSchema.nullable(),
+  // Premium comes from an auto-renewing subscription (which keeps the price it
+  // was created with) rather than from a one-time purchase. Defaulted for user
+  // data persisted before the field existed; `authInit` refreshes it.
+  premiumSubscription: z.boolean().default(false),
   sendGalleryEmails: z.boolean(),
   hasPicture: z.boolean(),
   settings: UserSettingsSchema.optional(),

--- a/src/features/premium/components/PremiumActivationModal.tsx
+++ b/src/features/premium/components/PremiumActivationModal.tsx
@@ -1,10 +1,19 @@
 import { useDocumentTitle } from '@app/hooks/useDocumentTitle.js';
 import { purchase, setActiveModal } from '@app/store/actions.js';
 import { useMessages } from '@features/l10n/l10nInjector.js';
+import { useAppSelector } from '@shared/hooks/useAppSelector.js';
+import { useDateTimeFormat } from '@shared/hooks/useDateTimeFormat.js';
+import {
+  PREMIUM_PRICE_EUR,
+  PREMIUM_PRICE_INCREASE_AT,
+  PREMIUM_WINBACK_PRICE_EUR,
+} from '@shared/premiumPricing.js';
 import type { ReactElement } from 'react';
-import { Button, ButtonGroup, Dropdown, Modal } from 'react-bootstrap';
+import { Alert, Button, ButtonGroup, Dropdown, Modal } from 'react-bootstrap';
 import { FaGem, FaRegGem, FaStopwatch, FaTimes } from 'react-icons/fa';
 import { useDispatch } from 'react-redux';
+import { useWinbackOffer } from '../hooks/useWinbackOffer.js';
+import { isPremiumWithoutSubscription } from '../premium.js';
 import { usePremiumMessages } from '../translations/usePremiumMessages.js';
 
 type Props = { show: boolean };
@@ -18,10 +27,28 @@ export default function PremiumActivationModal({ show }: Props): ReactElement {
 
   useDocumentTitle(show ? prm?.title : undefined);
 
+  const authToken = useAppSelector((state) => state.auth.user?.authToken);
+
+  // Someone holding a one-time year is told to switch, not to buy: the
+  // subscription starts charging only once that year runs out.
+  const switching = useAppSelector((state) =>
+    isPremiumWithoutSubscription(state.auth.user),
+  );
+
+  const winback = useWinbackOffer(show ? authToken : undefined);
+
+  const dateFormat = useDateTimeFormat({
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
   function close() {
     dispatch(setActiveModal(null));
   }
 
+  // The backend gives an eligible user the win-back price on any yearly
+  // subscription, so nothing about the offer has to be sent from here.
   function buy(opts: { recurring?: boolean; via?: 'rovas' } = {}) {
     dispatch(setActiveModal(null));
 
@@ -37,7 +64,20 @@ export default function PremiumActivationModal({ show }: Props): ReactElement {
       </Modal.Header>
 
       <Modal.Body>
-        {prm?.commonHeader}
+        {prm?.commonHeader(PREMIUM_PRICE_EUR)}
+
+        <Alert variant="warning" className="mt-3 mb-0">
+          {winback
+            ? prm?.winbackOffer({
+                price: PREMIUM_WINBACK_PRICE_EUR,
+                expiredAt: dateFormat.format(new Date(winback.expiredAt)),
+              })
+            : (switching ? prm?.priceIncreaseSwitch : prm?.priceIncrease)?.({
+                date: dateFormat.format(PREMIUM_PRICE_INCREASE_AT),
+                oldPrice: PREMIUM_PRICE_EUR,
+                newPrice: 15,
+              })}
+        </Alert>
 
         <hr />
 
@@ -47,7 +87,10 @@ export default function PremiumActivationModal({ show }: Props): ReactElement {
       <Modal.Footer>
         <Dropdown as={ButtonGroup}>
           <Button variant="primary" onClick={() => buy({ recurring: true })}>
-            <FaGem /> {prm?.paySubscription}
+            <FaGem />{' '}
+            {winback
+              ? prm?.winbackAccept({ price: PREMIUM_WINBACK_PRICE_EUR })
+              : prm?.paySubscription}
           </Button>
 
           <Dropdown.Toggle split variant="primary" id="premium-buy" />

--- a/src/features/premium/hooks/usePremiumPriceIncreaseInfo.tsx
+++ b/src/features/premium/hooks/usePremiumPriceIncreaseInfo.tsx
@@ -1,0 +1,81 @@
+import { ShowModalLink } from '@shared/components/ShowModalLink.js';
+import { useAppSelector } from '@shared/hooks/useAppSelector.js';
+import { useDateTimeFormat } from '@shared/hooks/useDateTimeFormat.js';
+import {
+  PREMIUM_PRICE_EUR,
+  PREMIUM_PRICE_INCREASE_AT,
+} from '@shared/premiumPricing.js';
+import { type ReactNode, useState } from 'react';
+import { Anchor } from 'react-bootstrap';
+import { isPremiumWithoutSubscription } from '../premium.js';
+import { usePremiumMessages } from '../translations/usePremiumMessages.js';
+
+/**
+ * Info bar announcing the upcoming premium price increase, or `null` when there
+ * is nothing to show yet (its messages load in a separate chunk) — the caller
+ * uses that to keep the bar itself out of the page.
+ *
+ * The full sentence doesn't fit a phone, so up to `md` it shrinks to a headline
+ * that expands to the full text on demand.
+ */
+export function usePremiumPriceIncreaseInfo(): ReactNode {
+  const prm = usePremiumMessages();
+
+  const [expanded, setExpanded] = useState(false);
+
+  // Someone holding a one-time year is told to switch instead of to buy.
+  const switching = useAppSelector((state) =>
+    isPremiumWithoutSubscription(state.auth.user),
+  );
+
+  const dateFormat = useDateTimeFormat({
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+  const shortDateFormat = useDateTimeFormat({
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+  });
+
+  if (!prm) {
+    return null;
+  }
+
+  const params = {
+    date: dateFormat.format(PREMIUM_PRICE_INCREASE_AT),
+    oldPrice: PREMIUM_PRICE_EUR,
+    newPrice: 15,
+  };
+
+  const full = (
+    <>
+      {switching
+        ? prm.priceIncreaseSwitch(params)
+        : prm.priceIncreaseShort(params)}{' '}
+      <ShowModalLink modal="premium">
+        {switching ? prm.paySubscription : prm.becomePremium}
+      </ShowModalLink>
+    </>
+  );
+
+  return expanded ? (
+    full
+  ) : (
+    <>
+      <span className="d-md-none">
+        {prm.priceIncreaseMini({
+          date: shortDateFormat.format(PREMIUM_PRICE_INCREASE_AT),
+          newPrice: 15,
+        })}{' '}
+        <Anchor onClick={() => setExpanded(true)}>
+          {prm.priceIncreaseMore}
+        </Anchor>
+      </span>
+
+      <span className="d-none d-md-inline">{full}</span>
+    </>
+  );
+}

--- a/src/features/premium/hooks/useWinbackOffer.ts
+++ b/src/features/premium/hooks/useWinbackOffer.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import z from 'zod';
+
+const WinbackOfferSchema = z.object({
+  eligible: z.boolean(),
+  // Set only when eligible: when the user's premium access ran out.
+  expiredAt: z.iso.datetime().nullable(),
+});
+
+type WinbackOffer = { expiredAt: string };
+
+/**
+ * Personal offer for a lapsed one-time buyer to return at the original yearly
+ * price. Eligibility is decided by the backend (which also re-checks it when
+ * the checkout is created); `undefined` means unknown or not eligible.
+ */
+export function useWinbackOffer(
+  authToken: string | undefined,
+): WinbackOffer | undefined {
+  const [offer, setOffer] = useState<WinbackOffer>();
+
+  useEffect(() => {
+    setOffer(undefined);
+
+    if (!authToken) {
+      return;
+    }
+
+    const ac = new AbortController();
+
+    (async () => {
+      const res = await fetch(
+        `${process.env['API_URL']}/auth/premium/winback`,
+        {
+          signal: ac.signal,
+          headers: {
+            accept: 'application/json',
+            authorization: `Bearer ${authToken}`,
+          },
+        },
+      );
+
+      if (!res.ok) {
+        throw new Error(`winback offer lookup failed: ${res.status}`);
+      }
+
+      const { eligible, expiredAt } = WinbackOfferSchema.parse(
+        await res.json(),
+      );
+
+      if (eligible && expiredAt) {
+        setOffer({ expiredAt });
+      }
+    })().catch((err) => {
+      if (!ac.signal.aborted) {
+        console.error(err);
+      }
+    });
+
+    return () => {
+      ac.abort();
+    };
+  }, [authToken]);
+
+  return offer;
+}

--- a/src/features/premium/premium.ts
+++ b/src/features/premium/premium.ts
@@ -5,3 +5,15 @@ export function isPremium(
 ): boolean {
   return user?.premiumExpiration != null && user.premiumExpiration > new Date();
 }
+
+/**
+ * Premium held as a one-time year rather than as a subscription. Such a user is
+ * the one to tell about the price increase: subscribing before it locks the
+ * current price, and the subscription only starts charging once the year they
+ * already paid for runs out.
+ */
+export function isPremiumWithoutSubscription(
+  user: Pick<User, 'premiumExpiration' | 'premiumSubscription'> | null,
+): boolean {
+  return isPremium(user) && !user?.premiumSubscription;
+}

--- a/src/features/premium/translations/PremiumMessages.ts
+++ b/src/features/premium/translations/PremiumMessages.ts
@@ -2,7 +2,7 @@ import type { JSX, ReactNode } from 'react';
 
 export type PremiumMessages = {
   title: string;
-  commonHeader: ReactNode;
+  commonHeader: (price: number) => ReactNode;
   stepsForAnonymous: ReactNode;
   success: string;
   becomePremium: string;
@@ -17,4 +17,27 @@ export type PremiumMessages = {
   paySubscription: string;
   payWithChrons: string;
   chronsHint: ReactNode;
+  priceIncrease: (params: {
+    date: string;
+    oldPrice: number;
+    newPrice: number;
+  }) => string;
+  /** Shorter variant of `priceIncrease` for the info bar. */
+  priceIncreaseShort: (params: {
+    date: string;
+    oldPrice: number;
+    newPrice: number;
+  }) => string;
+  /** For a user whose premium is a one-time year, not a subscription. */
+  priceIncreaseSwitch: (params: {
+    date: string;
+    oldPrice: number;
+    newPrice: number;
+  }) => string;
+  /** Headline for the info bar on a phone, paired with `priceIncreaseMore`. */
+  priceIncreaseMini: (params: { date: string; newPrice: number }) => string;
+  /** Label of the link to the premium document. */
+  priceIncreaseMore: string;
+  winbackOffer: (params: { price: number; expiredAt: string }) => string;
+  winbackAccept: (params: { price: number }) => string;
 };

--- a/src/features/premium/translations/cs.template.tsx
+++ b/src/features/premium/translations/cs.template.tsx
@@ -4,14 +4,14 @@ import type { PremiumMessages } from './PremiumMessages.js';
 
 const cs: DeepPartialWithRequiredObjects<PremiumMessages> = {
   title: 'Získat prémiový přístup',
-  commonHeader: (
+  commonHeader: (price) => (
     <>
       <p>
         <strong>Freemap Premium</strong> je volitelné roční předplatné, které
         rozšiřuje aplikaci.
       </p>
       <p className="mb-1">
-        Za <b>8 €</b> ročně získáte:
+        Za <b>{price} €</b> ročně získáte:
       </p>
       <ul>
         <li>odstranění reklamního baneru</li>

--- a/src/features/premium/translations/de.template.tsx
+++ b/src/features/premium/translations/de.template.tsx
@@ -5,14 +5,14 @@ import type { PremiumMessages } from './PremiumMessages.js';
 const de: DeepPartialWithRequiredObjects<PremiumMessages> = {
   title: 'Premium-Zugang erhalten',
 
-  commonHeader: (
+  commonHeader: (price) => (
     <>
       <p>
         <strong>Freemap Premium</strong> ist ein optionales Jahresabo, das die
         App erweitert.
       </p>
       <p className="mb-1">
-        Für <b>8 €</b> pro Jahr erhältst du:
+        Für <b>{price} €</b> pro Jahr erhältst du:
       </p>
       <ul>
         <li>entferntes Werbebanner</li>

--- a/src/features/premium/translations/en.messages.tsx
+++ b/src/features/premium/translations/en.messages.tsx
@@ -3,14 +3,14 @@ import type { PremiumMessages } from './PremiumMessages.js';
 
 const en: PremiumMessages = {
   title: 'Get premium access',
-  commonHeader: (
+  commonHeader: (price) => (
     <>
       <p>
         <strong>Freemap Premium</strong> is an optional yearly subscription that
         enhances the app.
       </p>
       <p className="mb-1">
-        For <b>8 €</b> per year you get:
+        For <b>{price} €</b> per year you get:
       </p>
       <ul>
         <li>removed ad banner</li>
@@ -65,6 +65,18 @@ const en: PremiumMessages = {
       <RovasLink>Rovas</RovasLink>, choose to pay with Chrons.
     </>
   ),
+  priceIncrease: ({ date, oldPrice, newPrice }) =>
+    `On ${date} the price of premium access rises from ${oldPrice}\xa0€ to ${newPrice}\xa0€ per year. Subscribe before that date and you keep the ${oldPrice}\xa0€ price for as long as your subscription stays active. A one-time purchase costs ${oldPrice}\xa0€ for that one year only — the next one is at the price valid at the time.`,
+  priceIncreaseShort: ({ date, oldPrice, newPrice }) =>
+    `From ${date} premium access costs ${newPrice}\xa0€ a year. Subscribe before then for ${oldPrice}\xa0€ and keep that price for as long as your subscription stays active.`,
+  priceIncreaseSwitch: ({ date, oldPrice, newPrice }) =>
+    `From ${date} premium access costs ${newPrice}\xa0€ a year. Switch to a subscription before then and you keep the ${oldPrice}\xa0€ price for as long as it stays active — it starts charging only when the year you have already paid for runs out, so you pay nothing twice.`,
+  priceIncreaseMini: ({ date, newPrice }) =>
+    `Premium ${newPrice}\xa0€ a year from ${date}.`,
+  priceIncreaseMore: 'more…',
+  winbackOffer: ({ price, expiredAt }) =>
+    `Your premium access expired on ${expiredAt}. As a former customer you can come back to the original price: an auto-renewing yearly subscription for ${price}\xa0€, kept for as long as it stays active. This offer is for you only and can be used once.`,
+  winbackAccept: ({ price }) => `Subscribe for ${price}\xa0€ a year`,
 };
 
 export default en;

--- a/src/features/premium/translations/fr.template.tsx
+++ b/src/features/premium/translations/fr.template.tsx
@@ -4,14 +4,14 @@ import type { PremiumMessages } from './PremiumMessages.js';
 
 const fr: DeepPartialWithRequiredObjects<PremiumMessages> = {
   title: 'Obtenir l’accès premium',
-  commonHeader: (
+  commonHeader: (price) => (
     <>
       <p>
         <strong>Freemap Premium</strong> est un abonnement annuel facultatif qui
         enrichit l’application.
       </p>
       <p className="mb-1">
-        Pour <b>8 €</b> par an, vous obtenez :
+        Pour <b>{price} €</b> par an, vous obtenez :
       </p>
       <ul>
         <li>la suppression de la bannière publicitaire</li>

--- a/src/features/premium/translations/hu.template.tsx
+++ b/src/features/premium/translations/hu.template.tsx
@@ -4,14 +4,14 @@ import type { PremiumMessages } from './PremiumMessages.js';
 
 const hu: DeepPartialWithRequiredObjects<PremiumMessages> = {
   title: 'Prémium hozzáférés megszerzése',
-  commonHeader: (
+  commonHeader: (price) => (
     <>
       <p>
         A <strong>Freemap Premium</strong> egy opcionális éves előfizetés, amely
         kibővíti az alkalmazást.
       </p>
       <p className="mb-1">
-        <b>8 €</b> összegért évente a következőket kapod:
+        <b>{price} €</b> összegért évente a következőket kapod:
       </p>
       <ul>
         <li>reklámszalag eltávolítása</li>

--- a/src/features/premium/translations/it.template.tsx
+++ b/src/features/premium/translations/it.template.tsx
@@ -4,14 +4,14 @@ import type { PremiumMessages } from './PremiumMessages.js';
 
 const it: DeepPartialWithRequiredObjects<PremiumMessages> = {
   title: 'Ottieni accesso premium',
-  commonHeader: (
+  commonHeader: (price) => (
     <>
       <p>
         <strong>Freemap Premium</strong> è un abbonamento annuale facoltativo
         che potenzia l’app.
       </p>
       <p>
-        Con <b>8 €</b> all’anno ottieni:
+        Con <b>{price} €</b> all’anno ottieni:
       </p>
       <ul>
         <li>rimozione del banner pubblicitario</li>

--- a/src/features/premium/translations/pl.template.tsx
+++ b/src/features/premium/translations/pl.template.tsx
@@ -4,14 +4,14 @@ import type { PremiumMessages } from './PremiumMessages.js';
 
 const pl: DeepPartialWithRequiredObjects<PremiumMessages> = {
   title: 'Uzyskaj dostęp premium',
-  commonHeader: (
+  commonHeader: (price) => (
     <>
       <p>
         <strong>Freemap Premium</strong> to opcjonalna roczna subskrypcja, która
         rozszerza aplikację.
       </p>
       <p className="mb-1">
-        Za <b>8 €</b> rocznie otrzymasz:
+        Za <b>{price} €</b> rocznie otrzymasz:
       </p>
       <ul>
         <li>usunięcie banera reklamowego</li>

--- a/src/features/premium/translations/sk.template.tsx
+++ b/src/features/premium/translations/sk.template.tsx
@@ -4,14 +4,14 @@ import type { PremiumMessages } from './PremiumMessages.js';
 
 const sk: DeepPartialWithRequiredObjects<PremiumMessages> = {
   title: 'Získať prémiový prístup',
-  commonHeader: (
+  commonHeader: (price) => (
     <>
       <p>
         <strong>Freemap Premium</strong> je voliteľné ročné predplatné, ktoré
         rozširuje aplikáciu.
       </p>
       <p className="mb-1">
-        Za <b>8 €</b> ročne získate:
+        Za <b>{price} €</b> ročne získate:
       </p>
       <ul>
         <li>odstránenie reklamného baneru</li>
@@ -66,6 +66,18 @@ const sk: DeepPartialWithRequiredObjects<PremiumMessages> = {
       <RovasLink>Rováši</RovasLink>, zvoľte platbu chronmi.
     </>
   ),
+  priceIncrease: ({ date, oldPrice, newPrice }) =>
+    `${date} sa cena prémiového prístupu zvyšuje z ${oldPrice}\xa0€ na ${newPrice}\xa0€ ročne. Ak si predplatné aktivujete pred týmto dátumom, cena ${oldPrice}\xa0€ vám zostane, pokiaľ bude predplatné aktívne. Jednorazová platba platí za ${oldPrice}\xa0€ len na daný jeden rok — ďalší rok si kúpite za cenu platnú v tom čase.`,
+  priceIncreaseShort: ({ date, oldPrice, newPrice }) =>
+    `Od ${date} stojí prémiový prístup ${newPrice}\xa0€ ročne. Ak si ho predplatíte skôr, cena ${oldPrice}\xa0€ vám zostane, pokiaľ bude predplatné aktívne.`,
+  priceIncreaseSwitch: ({ date, oldPrice, newPrice }) =>
+    `Od ${date} stojí prémiový prístup ${newPrice}\xa0€ ročne. Ak dovtedy prejdete na predplatné, cena ${oldPrice}\xa0€ vám zostane, pokiaľ bude aktívne — účtovať sa začne až po vyčerpaní roka, ktorý už máte zaplatený, takže nič neplatíte dvakrát.`,
+  priceIncreaseMini: ({ date, newPrice }) =>
+    `Prémium od ${date} za ${newPrice}\xa0€ ročne.`,
+  priceIncreaseMore: 'viac…',
+  winbackOffer: ({ price, expiredAt }) =>
+    `Váš prémiový prístup vypršal ${expiredAt}. Ako bývalý zákazník sa môžete vrátiť za pôvodnú cenu: ročné predplatné s automatickým obnovením za ${price}\xa0€, ktoré vám zostane, pokiaľ bude aktívne. Táto ponuka je určená len vám a dá sa využiť raz.`,
+  winbackAccept: ({ price }) => `Predplatiť si za ${price}\xa0€ ročne`,
 };
 
 export default sk;

--- a/src/features/premium/translations/sl.template.tsx
+++ b/src/features/premium/translations/sl.template.tsx
@@ -4,14 +4,14 @@ import type { PremiumMessages } from './PremiumMessages.js';
 
 const sl: DeepPartialWithRequiredObjects<PremiumMessages> = {
   title: 'Pridobi premium dostop',
-  commonHeader: (
+  commonHeader: (price) => (
     <>
       <p>
         <strong>Freemap Premium</strong> je izbirna letna naročnina, ki nadgradi
         aplikacijo.
       </p>
       <p className="mb-1">
-        Za <b>8 €</b> na leto dobite:
+        Za <b>{price} €</b> na leto dobite:
       </p>
       <ul>
         <li>odstranjeno oglasno pasico</li>

--- a/src/shared/premiumPricing.ts
+++ b/src/shared/premiumPricing.ts
@@ -1,0 +1,27 @@
+// Freemap Premium costs 8 €/year; on 1 September 2026 the price rises to
+// 15 €/year for new customers. An auto-renewing subscription started before
+// then keeps its price for as long as it stays active (the payment provider
+// grandfathers it), while a one-time purchase locks the price for the bought
+// year only.
+//
+// Nothing here switches by itself. On that day set `PREMIUM_PRICE_EUR` to 15,
+// drop the announcement, and repoint the product IDs in the backend env — see
+// TODO.md; all three have to happen together.
+
+/** What premium is sold for right now. */
+export const PREMIUM_PRICE_EUR = 8;
+
+/**
+ * What the win-back offer is sold for. Pinned to the unlisted 8 € product in
+ * Polar (`POLAR_PREMIUM_WINBACK_PRODUCT_ID`), so it does *not* follow
+ * `PREMIUM_PRICE_EUR` when that goes up.
+ */
+export const PREMIUM_WINBACK_PRICE_EUR = 8;
+
+/**
+ * Only used to render the date in the announcement — midday, so that every
+ * timezone formats it as 1 September.
+ */
+export const PREMIUM_PRICE_INCREASE_AT = Date.parse(
+  '2026-09-01T12:00:00+02:00',
+);

--- a/src/static/llms.txt
+++ b/src/static/llms.txt
@@ -75,6 +75,7 @@ The Account modal has three collapsible sections (below); from the buttons at th
 - Shows current premium status (e.g. "premium access until <date>") and the credit balance, with a **Buy credits** button
 - History of purchases (date and item)
 - Users can purchase yearly premium access and/or credits
+- Yearly premium costs 8 € up to 31 August 2026 and 15 € from 1 September 2026; it is bought either as an auto-renewing subscription (which keeps the price it was started at) or as a one-time year (which keeps the price for that year only). Until the increase, an info bar and a notice in the "Get premium access" modal announce it. A customer whose one-time year has lapsed is offered a personal, single-use win-back subscription at the original 8 €
 - Credits are currently spent only on "Offline maps export" (see description below)
 - Yearly premium allows:
   - Removal of the ad banner


### PR DESCRIPTION
Premium goes from 8 € to 15 € a year for new customers on **1 September 2026**. Until then an info bar and a notice in the purchase modal say so.

## What this does

- **Announcement** — info bar + purchase-modal notice about the upcoming price change, with separate wording for someone holding a one-time year: they can still switch to a subscription and lock the current price, and the subscription only starts charging when their paid year runs out.
- **Existing subscribers** keep their price and are left alone.
- **Win-back** — a customer whose one-time year lapsed is offered a return at the original price. The backend decides eligibility and prices the checkout; this side only asks whether to advertise the offer.
- **Info-bar rotation** — bars now rotate by least-recently-shown, persisted alongside the dismissals, so a standing announcement can no longer starve the others.

## Notes

Nothing flips by itself — the checklist for switch-over day is in `TODO.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)