### PR TITLE
fix(weatherRadar): version forecast tiles, and key invalidation on the cycle

### DIFF
--- a/doc/weather-radar.md
+++ b/doc/weather-radar.md
@@ -118,12 +118,17 @@ Everything the app knows about the API lives in `src/features/weatherRadar/api.t
   Each frame is `{ time (unix seconds), path }`. Currently 12 past frames and 6
   nowcast frames, ten minutes apart — but nothing in the code assumes those
   counts.
-- Tiles: `{path}/{size}/{z}/{x}/{y}/{colorScheme}/{smooth}_{snow}.webp`. WebP
+- Tiles: `{path}/{size}/{z}/{x}/{y}/{colorScheme}/{smooth}_{snow}.webp[?v=]`. WebP
   because a radar tile is about half the size of the same frame as PNG, and the
   animation fetches one per frame. `size` is 256 or 512 for the *same* ground —
   512 is simply the @2x render, so it is what a HiDPI screen gets
   (`resolutionScale ?? devicePixelRatio > 1.4`), displayed at Leaflet's usual
-  256 CSS px.
+  256 CSS px. Forecast tiles carry `?v=<newest observed frame time>`, because
+  their content changes under a fixed URL and the browser would otherwise answer
+  the re-fetch from its own five-minute cache. Observed tiles carry no version:
+  they never change, and churning their URLs would re-render six hours of
+  history every cycle. Note the version is **not** the metadata's `generated`,
+  which ticks on every fetch rather than every cycle.
 
 `toFrames` merges the two lists into the single timeline the UI animates,
 tagging the nowcast half with `forecast: true`. That flag is what colours the

--- a/src/features/weatherRadar/api.ts
+++ b/src/features/weatherRadar/api.ts
@@ -58,12 +58,23 @@ export type RadarTileOptions = {
 /**
  * Leaflet URL template for one frame. WebP because a radar tile halves in size
  * against the PNG of the same frame, and the animation fetches a tile per frame.
+ *
+ * `version` is appended for frames whose content changes under a fixed URL —
+ * the forecast half, re-computed from newer radar each cycle. Without it the
+ * browser answers the re-fetch from its own five-minute cache and the new
+ * forecast is invisible for up to that long. Observed frames pass no version:
+ * they never change, and churning their URLs would re-render six hours of
+ * history every cycle.
  */
 export function radarTileUrl(
   path: string,
   { colorScheme, smooth, snow, size }: RadarTileOptions,
+  version?: number,
 ): string {
-  return `${LIBREWXR_URL}${path}/${size}/{z}/{x}/{y}/${colorScheme}/${smooth ? 1 : 0}_${snow ? 1 : 0}.webp`;
+  return (
+    `${LIBREWXR_URL}${path}/${size}/{z}/{x}/{y}/${colorScheme}/${smooth ? 1 : 0}_${snow ? 1 : 0}.webp` +
+    (version === undefined ? '' : `?v=${version}`)
+  );
 }
 
 /** Merges the two frame lists into the single timeline the UI animates. */

--- a/src/features/weatherRadar/components/RadarLayer.tsx
+++ b/src/features/weatherRadar/components/RadarLayer.tsx
@@ -56,8 +56,16 @@ export default function RadarLayer({
 
   const playing = useAppSelector((state) => state.weatherRadar.playing);
 
-  /** Bumped by the server on every fetch cycle; the forecast is redrawn then. */
-  const generated = useAppSelector((state) => state.weatherRadar.generated);
+  /**
+   * The newest observed frame, which is the layer's notion of a server cycle:
+   * it advances exactly once per composite, and its arrival is what re-computes
+   * the forecast. `generated` in the metadata looks like the same thing but
+   * ticks on every fetch, so keying on it would invalidate several times a
+   * cycle for nothing.
+   */
+  const cycle = useAppSelector(
+    (state) => state.weatherRadar.frames.findLast((f) => !f.forecast)?.time,
+  );
 
   const colorScheme = useAppSelector(
     (state) => state.weatherRadarSettings.colorScheme,
@@ -123,16 +131,19 @@ export default function RadarLayer({
       return;
     }
 
-    const layer = new TileLayer(radarTileUrl(frame.path, tileOptions), {
-      opacity: 0,
-      zIndex,
-      maxZoom,
-      maxNativeZoom,
-      errorTileUrl: transparent1x1,
-      // A frame is one moment in time: tiles kept from the previous view would
-      // be redrawn at a zoom this frame is no longer showing.
-      keepBuffer: 0,
-    });
+    const layer = new TileLayer(
+      radarTileUrl(frame.path, tileOptions, frame.forecast ? cycle : undefined),
+      {
+        opacity: 0,
+        zIndex,
+        maxZoom,
+        maxNativeZoom,
+        errorTileUrl: transparent1x1,
+        // A frame is one moment in time: tiles kept from the previous view
+        // would be redrawn at a zoom this frame is no longer showing.
+        keepBuffer: 0,
+      },
+    );
 
     // `load` fires once every tile has settled — and an errored tile counts as
     // settled, because `errorTileUrl` renders in its place. So the outcome has
@@ -244,7 +255,7 @@ export default function RadarLayer({
 
   const frame = frames[index];
 
-  const generatedRef = useRef(generated);
+  const cycleRef = useRef(cycle);
 
   // Everything the pool has to unlearn when a new frame list lands. Ahead of
   // the effect that shows a frame, so a layer dropped here is rebuilt in the
@@ -258,9 +269,9 @@ export default function RadarLayer({
     // the same URL, so the layer holding the previous version would never ask
     // for the new one. Observed composites don't change once published, and
     // they are the bulk of the pool.
-    const republished = generatedRef.current !== generated;
+    const republished = cycleRef.current !== cycle;
 
-    generatedRef.current = generated;
+    cycleRef.current = cycle;
 
     for (const [frameTime, entry] of layersRef.current) {
       const frame = current.get(frameTime);
@@ -287,7 +298,7 @@ export default function RadarLayer({
         dropFrameRef.current(frameTime);
       }
     }
-  }, [frames, generated]);
+  }, [frames, cycle]);
 
   const optionsRef = useRef(tileOptions);
 

--- a/src/features/weatherRadar/components/RadarTimeline.tsx
+++ b/src/features/weatherRadar/components/RadarTimeline.tsx
@@ -38,7 +38,17 @@ export function RadarTimeline() {
 
   const observed = frames.filter((f) => !f.forecast).length;
 
-  const split = frames.length < 2 ? 100 : (observed / frames.length) * 100;
+  // Where the tint starts. The thumb sits at `index / (count - 1)` of the
+  // track, so the boundary between measured and extrapolated lies midway
+  // between the last observed frame and the first forecast one — not at the
+  // observed share of the count, which is half a step off.
+  const split =
+    frames.length < 2
+      ? 100
+      : Math.min(
+          100,
+          Math.max(0, ((observed - 0.5) / (frames.length - 1)) * 100),
+        );
 
   const minutes = Math.round((frame.time * 1000 - Date.now()) / 60_000);
 


### PR DESCRIPTION
The two items the branch review deliberately left as design calls rather than
bug fixes. Both turned out to have a clearly right answer.

## Forecast tiles are versioned

Dropping a republished forecast layer only forces a *re-request* — the browser
can still answer it from its own five-minute cache, so a newly computed
forecast stayed invisible for up to that long. Forecast tiles now carry
`?v=<cycle>`.

Observed tiles deliberately carry no version: they never change, and churning
their URLs would re-render six hours of history every cycle. That asymmetry is
the whole reason this is cheap rather than expensive.

## The cycle is the newest observed frame, not `generated`

`generated` in the metadata looks like the obvious version signal and isn't —
measured moving 92 s apart while the frame list stayed put, so it ticks per
fetch, not per composite. It was already making the drop-on-republish fire
several times a cycle for nothing, and as a cache key it would have been
actively harmful. The newest observed frame's time advances exactly once per
cycle and is identical for every client.

## Timeline tint

The tint began at the observed share of the frame count, while the thumb sits
at `index / (count - 1)`. At 36 observed of 42 that put the boundary at 85.7%
and the thumb for the newest observed frame at 85.4% — so when live, the thumb
appeared to be inside the forecast already. It now starts midway between the
last observed frame and the first forecast one.

Checks: `tsc`, `biome check`, 528 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)