### PR TITLE
feat(drawing): show the cut-a-hole hint as a dismissable toast

### DIFF
--- a/src/features/drawing/components/DrawingLineSelection.tsx
+++ b/src/features/drawing/components/DrawingLineSelection.tsx
@@ -4,6 +4,7 @@ import {
   elevationChartOpen,
 } from '@features/elevationChart/model/actions.js';
 import { useMessages } from '@features/l10n/l10nInjector.js';
+import { type ToastAction, toastsAdd } from '@features/toasts/model/actions.js';
 import { FmDropdownMenu } from '@shared/components/FmDropdownMenu.js';
 import { LongPressTooltip } from '@shared/components/LongPressTooltip.js';
 import { Selection } from '@shared/components/Selection.js';
@@ -37,7 +38,9 @@ import {
   drawingLineSetHoleOf,
   drawingLineSimplify,
   drawingLineStopDrawing,
+  drawingPreventCutHoleHint,
 } from '../model/actions/drawingLineActions.js';
+import { loadDrawingMessages } from '../translations/loadDrawingMessages.js';
 import { useDrawingMessages } from '../translations/useDrawingMessages.js';
 import { DrawingToggleButton } from './DrawingToggleButton.js';
 import { ProjectPointModal } from './ProjectPointModal.js';
@@ -74,6 +77,15 @@ export default function DrawingLineSelection(): ReactElement | null {
 
   const cuttingHole = useAppSelector(
     (state) => line !== undefined && state.drawingLines.holeFor === line.id,
+  );
+
+  const preventCutHoleHint = useAppSelector(
+    (state) => state.drawingSettings.preventCutHoleHint,
+  );
+
+  // Offering "don't show next time" only once the pref can outlive the session.
+  const canRememberHintPref = useAppSelector(
+    (state) => state.cookieConsent.cookieConsentResult !== null,
   );
 
   const isHole = line?.holeOfId !== undefined;
@@ -191,14 +203,41 @@ export default function DrawingLineSelection(): ReactElement | null {
       }
 
       switch (eventKey) {
-        case 'cut-hole':
+        case 'cut-hole': {
           // Opening a map-click tool disarms hole mode the same way it drops a
           // line being drawn, so arm it only once the tool is open.
           dispatch(openTool('draw-polygons'));
 
           dispatch(drawingLineCutHole({ parentLineIndex: lineIndex }));
 
+          if (!preventCutHoleHint) {
+            const actions: ToastAction[] = [{ nameKey: 'general.ok' }];
+
+            if (canRememberHintPref) {
+              actions.push({
+                nameKey: 'general.preventShowingAgain',
+                action: drawingPreventCutHoleHint(),
+                variant: 'dark',
+              });
+            }
+
+            dispatch(
+              toastsAdd({
+                id: 'drawing.cutHoleHint',
+                messageKey: 'cutHoleHint',
+                messageLoader: loadDrawingMessages,
+                style: 'info',
+                actions,
+                // Hole mode is spent once the hole's first point lands, and
+                // dropped when it is cancelled — either way the hint is done.
+                statePredicate: (state) =>
+                  state.drawingLines.holeFor === undefined,
+              }),
+            );
+          }
+
           break;
+        }
 
         case 'make-hole':
           dispatch(
@@ -248,7 +287,15 @@ export default function DrawingLineSelection(): ReactElement | null {
         }
       }
     },
-    [dispatch, enclosingIndex, lineIndex, m, toggleElevationChart],
+    [
+      canRememberHintPref,
+      dispatch,
+      enclosingIndex,
+      lineIndex,
+      m,
+      preventCutHoleHint,
+      toggleElevationChart,
+    ],
   );
 
   if (!line) {
@@ -289,27 +336,19 @@ export default function DrawingLineSelection(): ReactElement | null {
         noLeftMargin
       >
         {cuttingHole && (
-          <>
-            <span className="ms-2 me-1">{dm?.cutHoleHint}</span>
-
-            <LongPressTooltip
-              breakpoint="sm"
-              label={m?.general.cancel}
-              kbd="Esc"
-            >
-              {({ label, labelClassName, props }) => (
-                <Button
-                  className="ms-1"
-                  variant="secondary"
-                  onClick={() => dispatch(drawingLineStopDrawing())}
-                  {...props}
-                >
-                  <FaTimes />
-                  <span className={labelClassName}> {label}</span>
-                </Button>
-              )}
-            </LongPressTooltip>
-          </>
+          <LongPressTooltip breakpoint="sm" label={m?.general.cancel} kbd="Esc">
+            {({ label, labelClassName, props }) => (
+              <Button
+                className="ms-1"
+                variant="secondary"
+                onClick={() => dispatch(drawingLineStopDrawing())}
+                {...props}
+              >
+                <FaTimes />
+                <span className={labelClassName}> {label}</span>
+              </Button>
+            )}
+          </LongPressTooltip>
         )}
 
         {drawing && (

--- a/src/features/drawing/model/actions/drawingLineActions.ts
+++ b/src/features/drawing/model/actions/drawingLineActions.ts
@@ -197,6 +197,11 @@ export const drawingLineCutHole = createAction<{
   parentLineIndex: number;
 }>('DRAWING_LINE_CUT_HOLE');
 
+/** Stops the "draw the hole inside this polygon" hint from being shown again. */
+export const drawingPreventCutHoleHint = createAction(
+  'DRAWING_PREVENT_CUT_HOLE_HINT',
+);
+
 /** Attaches an existing polygon to a parent as a hole, or (`undefined`) frees it. */
 export const drawingLineSetHoleOf = createAction<{
   lineIndex: number;

--- a/src/features/drawing/model/reducers/drawingSettingsReducer.ts
+++ b/src/features/drawing/model/reducers/drawingSettingsReducer.ts
@@ -4,6 +4,7 @@ import { createReducer, isAnyOf } from '@reduxjs/toolkit';
 import z from 'zod';
 import {
   drawingLineChangeProperties,
+  drawingPreventCutHoleHint,
   LineCapSchema,
   LineJoinSchema,
 } from '../actions/drawingLineActions.js';
@@ -63,6 +64,7 @@ export function drawingStyleEquals(a: DrawingStyle, b: DrawingStyle): boolean {
 export const DrawingSettingsSchema = z.object({
   style: DrawingStyleSchema,
   recentColors: z.array(z.string()),
+  preventCutHoleHint: z.boolean(),
 });
 
 export type DrawingSettings = z.infer<typeof DrawingSettingsSchema>;
@@ -114,12 +116,14 @@ export const DrawingSettingsCompatSchema = z.preprocess(
   z.object({
     style: DrawingStyleSchema.partial(),
     recentColors: z.array(z.string()).optional(),
+    preventCutHoleHint: z.boolean().optional(),
   }),
 );
 
 export const drawingSettingsInitialState: DrawingSettings = {
   style: makeDrawingStyle('#0000ff', 4),
   recentColors: [],
+  preventCutHoleHint: false,
 };
 
 export const drawingSettingsReducer = createReducer(
@@ -168,6 +172,9 @@ export const drawingSettingsReducer = createReducer(
         if (fillColor) {
           updateRecentDrawingColors(state, fillColor);
         }
+      })
+      .addCase(drawingPreventCutHoleHint, (state) => {
+        state.preventCutHoleHint = true;
       })
       .addMatcher(
         isAnyOf(drawingLineChangeProperties, drawingPointChangeProperties),

--- a/src/features/drawing/translations/loadDrawingMessages.ts
+++ b/src/features/drawing/translations/loadDrawingMessages.ts
@@ -1,0 +1,25 @@
+import type { DrawingMessages } from './DrawingMessages.js';
+
+let cache: DrawingMessages | undefined;
+
+let cacheLang: string | undefined;
+
+// Loads the drawing messages for a language for use outside React (toast/error
+// dispatch). React components should use `useLocalMessages` instead. Results are
+// cached per language; the chunk is shared with the components' dynamic import.
+export async function loadDrawingMessages(
+  language: string,
+): Promise<DrawingMessages> {
+  if (cacheLang !== language) {
+    cache = (
+      await import(
+        /* webpackChunkName: "drawing-translation-[request]" */
+        `./${language}.messages.tsx`
+      )
+    ).default;
+
+    cacheLang = language;
+  }
+
+  return cache as DrawingMessages;
+}


### PR DESCRIPTION
Picking **Cut out a hole** on a selected polygon used to put a hint in the selection toolbar, where it stayed for as long as hole mode was armed — crowding the buttons next to it, with no way to dismiss it.

It is now an `info` toast, following the route planner's "drag a route segment to add a midpoint" hint:

- **OK** and **Don't show next time**, the latter only once cookie consent has been answered (otherwise the pref would not outlive the session).
- Closes itself on `statePredicate: state.drawingLines.holeFor === undefined`. That one predicate covers every exit: the hole's first point spends hole mode, and <kbd>Esc</kbd>, stop drawing, opening another map-click tool, closing the draw tool and selecting another feature all drop it.
- The toolbar keeps its **Cancel** button — that is an action, not a hint, and has to outlive dismissing the toast.

`preventCutHoleHint` is persisted in the `drawingSettings` slice rather than the transient `drawingLines` one, so a map clear cannot silently reset it.

The message reuses the existing `cutHoleHint` key, so every locale already has the string. `llms.txt` needed no change — it documents hole-cutting but has never described the hints.

## Test plan

- `tsc --noEmit` clean; `biome check` applied; the drawing reducer tests pass.
- Not yet exercised in the browser: pick **Cut out a hole** on a polygon, confirm the toast appears and disappears the moment the hole's first point lands, and that **Don't show next time** keeps it away across a reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)