### PR TITLE
feat(offline): show uncached tiles from the network while online

### DIFF
--- a/src/app/components/Layers.tsx
+++ b/src/app/components/Layers.tsx
@@ -1,10 +1,12 @@
 import { hasRole } from '@features/auth/model/types.js';
 import { getCachedTileScale } from '@features/cachedMaps/cachedTileMaps.js';
 import { toCachedLayerUrl } from '@features/cachedMaps/cachedTileUrl.js';
+import { sourceLayerEnvelope } from '@features/cachedMaps/sourceLayer.js';
 import { useMessages } from '@features/l10n/l10nInjector.js';
 import { isPremium } from '@features/premium/premium.js';
 import { usePremiumMessages } from '@features/premium/translations/usePremiumMessages.js';
 import { useAppSelector } from '@shared/hooks/useAppSelector.js';
+import { useOnline } from '@shared/hooks/useOnline.js';
 import {
   integratedLayerDefs,
   type LayerDef,
@@ -63,6 +65,8 @@ export function Layers(): ReactElement | null {
   const galleryDirtySeq = useAppSelector((state) => state.gallery.dirtySeq);
 
   const user = useAppSelector((state) => state.auth.user);
+
+  const online = useOnline();
 
   const language = useAppSelector((state) => state.l10n.language);
 
@@ -312,8 +316,9 @@ export function Layers(): ReactElement | null {
             effForcedScale ?? 'auto',
             effFeatureScale,
             layerDef.url,
-            // a grid layer takes its zoom bounds at construction, so an edited
-            // cached (or custom) map needs a remount to widen or narrow them
+            // a grid layer takes its zoom bounds at construction, so anything
+            // that moves them — an edit, or a cached map losing the connection
+            // it was borrowing its source layer's range from — needs a remount
             minZoom ?? 'auto',
             layerDef.maxNativeZoom ?? 'auto',
           ].join('-')}
@@ -369,13 +374,22 @@ export function Layers(): ReactElement | null {
         .map((cm) => {
           const url = toCachedLayerUrl(cm.url, cm.type);
 
+          // Online the map wears its source layer's zoom range and premium gate:
+          // the service worker fetches whatever the cache lacks, so it behaves
+          // as the layer itself would, checkerboard included. Offline it is only
+          // what was downloaded — its own range, upscaled past the deepest zoom
+          // it holds rather than left blank.
+          const envelope = online
+            ? sourceLayerEnvelope(cm.sourceType, customLayerDefs)
+            : undefined;
+
           // cors: false — cached tiles are served same-origin by the service
           // worker, so `crossOrigin` buys nothing, and the CORS-mode request it
           // produces makes Chrome's `cache.match` miss the stored entry.
           return getLayer(
             cm.technology === 'tile'
-              ? { ...cm, url, cors: false }
-              : { ...cm, url },
+              ? { ...cm, url, ...envelope, cors: false }
+              : { ...cm, url, ...envelope },
             getCachedTileScale(cm),
           );
         })}

--- a/src/features/cachedMaps/cachedTileUrl.ts
+++ b/src/features/cachedMaps/cachedTileUrl.ts
@@ -6,7 +6,14 @@ export function toCachedLayerUrl(realTemplate: string, mapId: string): string {
   return `${location.origin}${CACHED_TILE_PATH_PREFIX}${encodeURIComponent(mapId)}${pathFromTemplate}`;
 }
 
-export function parseCachedTileMapId(pathname: string): string | null {
+/**
+ * Splits a `/__cached__/<id>/<path>` pathname into the map it addresses and the
+ * path below it — which is the source layer's own path, since
+ * `toCachedLayerUrl` replaces nothing but the origin.
+ */
+export function parseCachedTilePath(
+  pathname: string,
+): { mapId: string; path: string } | null {
   if (!pathname.startsWith(CACHED_TILE_PATH_PREFIX)) {
     return null;
   }
@@ -19,5 +26,8 @@ export function parseCachedTileMapId(pathname: string): string | null {
     return null;
   }
 
-  return decodeURIComponent(rest.slice(0, slashIdx));
+  return {
+    mapId: decodeURIComponent(rest.slice(0, slashIdx)),
+    path: rest.slice(slashIdx),
+  };
 }

--- a/src/features/cachedMaps/components/CacheTilesForm.tsx
+++ b/src/features/cachedMaps/components/CacheTilesForm.tsx
@@ -4,6 +4,7 @@ import { MapAreaToggle } from '@features/mapArea/components/MapAreaToggle.js';
 import { useMapAreaSelection } from '@features/mapArea/useMapAreaSelection.js';
 import { LayerVisibilityFields } from '@features/mapSettings/components/LayerVisibilityFields.js';
 import { useOfflineMapExportMessages } from '@features/offlineMapExport/translations/useOfflineMapExportMessages.js';
+import { PremiumGem } from '@features/premium/components/PremiumGem.js';
 import { FmDropdownMenu } from '@shared/components/FmDropdownMenu.js';
 import { MapLayerItem } from '@shared/components/MapLayerItem.js';
 import { SelectToggle } from '@shared/components/SelectToggle.js';
@@ -19,8 +20,12 @@ import {
   integratedLayerDefs,
 } from '@shared/mapDefinitions.js';
 import { isInvalidInt } from '@shared/numberValidator.js';
-import { countCachedOf, countTilesInBbox } from '@shared/tileEnumeration.js';
-import { pickTileScale } from '@shared/tileUrl.js';
+import {
+  countCachedOf,
+  countTilesInBbox,
+  coverageIncludes,
+} from '@shared/tileEnumeration.js';
+import { pickSubdomain, pickTileScale } from '@shared/tileUrl.js';
 import {
   type ReactElement,
   type SubmitEvent,
@@ -52,6 +57,7 @@ import {
   cachedMapsSetView,
   cacheTilesStart,
 } from '../model/actions.js';
+import { premiumZoomLimit } from '../sourceLayer.js';
 import { useCachedMapsMessages } from '../translations/useCachedMapsMessages.js';
 
 type CacheableLayerDef = IntegratedLayerDef<IsTileLayerDef> & {
@@ -144,8 +150,24 @@ export function CacheTilesForm({ editing }: Props): ReactElement {
 
   const limitMinZoom = editing && !mapDef ? editing.minZoom : mapDef?.minZoom;
 
-  const limitMaxZoom =
+  const user = useAppSelector((state) => state.auth.user);
+
+  const premiumLimit = premiumZoomLimit(editing?.sourceType ?? mapType, user);
+
+  // The field keeps the range a map was given while premium: capping it below
+  // what is already downloaded would make even a rename delete tiles. Growing it
+  // is another matter — see `premiumWiden` — and fetching those zooms is refused
+  // outright by the download itself.
+  const sourceMaxZoom =
     editing && !mapDef ? editing.maxNativeZoom : mapDef?.maxNativeZoom;
+
+  const limitMaxZoom =
+    premiumLimit === undefined
+      ? sourceMaxZoom
+      : Math.min(
+          sourceMaxZoom ?? Infinity,
+          Math.max(premiumLimit, editing?.maxNativeZoom ?? 0),
+        );
 
   const [name, setName] = useState(editing?.name ?? '');
 
@@ -188,11 +210,11 @@ export function CacheTilesForm({ editing }: Props): ReactElement {
       String(
         Math.max(
           mapDef.minZoom ?? 0,
-          Math.min(mapDef.maxNativeZoom ?? Infinity, DEFAULT_MAX_ZOOM),
+          Math.min(limitMaxZoom ?? Infinity, DEFAULT_MAX_ZOOM),
         ),
       ),
     );
-  }, [mapDef, editing]);
+  }, [mapDef, editing, limitMaxZoom]);
 
   useEffect(() => {
     setName((prev) => {
@@ -236,6 +258,28 @@ export function CacheTilesForm({ editing }: Props): ReactElement {
     return Math.max(0, tileCount - held);
   }, [bbox, minZoom, maxZoom, editing, tileCount]);
 
+  // A map is allowed to keep premium zooms it already downloaded, but not to
+  // take them over ground it didn't cover — that would fetch premium tiles
+  // afresh. Only the part of the range past the limit is pinned this way, so
+  // the free zooms can still be widened. Where the new range stops short of the
+  // limit there is nothing to compare, and `coverageIncludes` says so.
+  const premiumWiden =
+    premiumLimit !== undefined &&
+    editing !== undefined &&
+    bbox !== undefined &&
+    !coverageIncludes(
+      {
+        bounds: editing.bounds,
+        minZoom: Math.max(editing.minZoom ?? 0, premiumLimit + 1),
+        maxZoom: editing.maxNativeZoom ?? 18,
+      },
+      {
+        bounds: bbox,
+        minZoom: Math.max(Number(minZoom), premiumLimit + 1),
+        maxZoom: Number(maxZoom),
+      },
+    );
+
   const cnf = useNumberFormat({
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
@@ -267,6 +311,10 @@ export function CacheTilesForm({ editing }: Props): ReactElement {
   // single lever on the size
   const { bytes: estimatedSize, sampling } = useTilesSizeEstimate({
     urlTemplate,
+    subdomain: pickSubdomain(
+      (editing && 'subdomains' in editing ? editing.subdomains : undefined) ??
+        mapDef?.subdomains,
+    ),
     bbox,
     minZoom: Number(minZoom),
     maxZoom: Number(maxZoom),
@@ -469,7 +517,15 @@ export function CacheTilesForm({ editing }: Props): ReactElement {
 
         {urlTemplate && (
           <Form.Group controlId="zoomRange" className="mb-3">
-            <Form.Label className="required">{ome?.zoomRange}</Form.Label>
+            <Form.Label className="required">
+              {ome?.zoomRange}
+
+              {/* the range stops short of the layer's premium zooms; the gem
+                  says why, there being no checkerboard on a cached map */}
+              {premiumLimit !== undefined && (
+                <PremiumGem className="ms-1" hint={cm?.premiumZoomHint} />
+              )}
+            </Form.Label>
 
             <InputGroup>
               <Form.Control
@@ -571,6 +627,12 @@ export function CacheTilesForm({ editing }: Props): ReactElement {
               )}
             </>
           )}
+
+        {premiumWiden && (
+          <Alert variant="warning" className="mt-3 mb-0">
+            {cm?.premiumWiden}
+          </Alert>
+        )}
       </Modal.Body>
 
       <Modal.Footer className="flex-wrap">
@@ -603,6 +665,7 @@ export function CacheTilesForm({ editing }: Props): ReactElement {
           disabled={
             invalidMinZoom ||
             invalidMaxZoom ||
+            premiumWiden ||
             !tileCount ||
             tileCount === Infinity ||
             !name.trim()

--- a/src/features/cachedMaps/model/cacheTilesProcessor.ts
+++ b/src/features/cachedMaps/model/cacheTilesProcessor.ts
@@ -1,4 +1,5 @@
 import type { Processor } from '@app/store/middleware/processorMiddleware.js';
+import type { User } from '@features/auth/model/types.js';
 import { mapToggleLayer } from '@features/map/model/actions.js';
 import { toastsAdd } from '@features/toasts/model/actions.js';
 import { cacheStaticAssets } from '@shared/offlineStaticCache.js';
@@ -10,7 +11,7 @@ import {
   type TileCoord,
   tileRangeIndex,
 } from '@shared/tileEnumeration.js';
-import { buildTileUrl, withTileScale } from '@shared/tileUrl.js';
+import { buildTileUrl, pickSubdomain, withTileScale } from '@shared/tileUrl.js';
 import { trackMatomo } from '@shared/trackMatomo.js';
 import type { Dispatch } from 'redux';
 import {
@@ -25,6 +26,7 @@ import {
   sameCoverage,
 } from '../cachedTileMaps.js';
 import { toCachedLayerUrl } from '../cachedTileUrl.js';
+import { premiumZoomLimit } from '../sourceLayer.js';
 import { loadCachedMapsMessages } from '../translations/loadCachedMapsMessages.js';
 import {
   cachedMapDeleted,
@@ -107,13 +109,18 @@ function updateMeta(
   };
 }
 
+/** The `{s}` host a tile of this map is fetched from; see `pickSubdomain`. */
+function tileSubdomain(meta: CachedTileMapDef): string {
+  return pickSubdomain('subdomains' in meta ? meta.subdomains : undefined);
+}
+
 function tileCacheKey(
   meta: CachedTileMapDef,
   [x, y, z]: TileCoord,
   scale: number | undefined,
 ): string {
   return toCachedLayerUrl(
-    withTileScale(buildTileUrl(meta.url, x, y, z), scale),
+    withTileScale(buildTileUrl(meta.url, x, y, z, tileSubdomain(meta)), scale),
     meta.type,
   );
 }
@@ -245,6 +252,7 @@ async function downloadTiles(
   def: CachedTileMapDef,
   dispatch: Dispatch,
   language: string,
+  user: Pick<User, 'premiumExpiration'> | null,
   abortController: AbortController = beginDownload(def.type),
 ) {
   const id = def.type;
@@ -253,7 +261,18 @@ async function downloadTiles(
 
   const { bounds, minZoom, maxZoom } = coverageOf(def);
 
-  const tiles = enumerateTilesInBbox(bounds, minZoom, maxZoom);
+  // The one place premium zooms are kept out of the cache, whichever path got
+  // here: a map carries the range it was given while the premium access lasted,
+  // and a resume or an edit of it answers to the form's cap no more than a
+  // hand-edited database entry would. A map gated this way stays incomplete —
+  // it is missing tiles, and saying otherwise would be a lie.
+  const premiumLimit = premiumZoomLimit(def.sourceType, user) ?? Infinity;
+
+  const gatedMaxZoom = Math.min(maxZoom, premiumLimit);
+
+  const gated = gatedMaxZoom < maxZoom;
+
+  const tiles = enumerateTilesInBbox(bounds, minZoom, gatedMaxZoom);
 
   let visited = 0;
   let sizeBytes = def.sizeBytes;
@@ -299,7 +318,7 @@ async function downloadTiles(
     const results = await Promise.allSettled(
       batch.map(async ([x, y, z]) => {
         const fetchUrl = withTileScale(
-          buildTileUrl(meta.url, x, y, z),
+          buildTileUrl(meta.url, x, y, z, tileSubdomain(meta)),
           meta.tileScale,
         );
 
@@ -365,10 +384,33 @@ async function downloadTiles(
   // them as present and would never add their size again.
   await commitMeta(
     dispatch,
-    updateMeta(meta, stopped ? cachedCount() : meta.tileCount, sizeBytes),
+    updateMeta(
+      meta,
+      stopped || gated ? cachedCount() : meta.tileCount,
+      sizeBytes,
+    ),
   );
 
-  if (!stopped) {
+  if (stopped) {
+    return;
+  }
+
+  // Ends the row's download whether or not every tile was allowed: it is what
+  // clears `activeDownloads`, and a gated pass has nothing left to do either.
+  dispatch(cacheTilesComplete({ id }));
+
+  if (gated) {
+    // Say why the map stops short of the range it was given, or a Resume that
+    // fetches nothing more looks like a failure.
+    dispatch(
+      toastsAdd({
+        style: 'warning',
+        timeout: 10_000,
+        messageKey: 'premiumSkipped',
+        messageLoader: loadCachedMapsMessages,
+      }),
+    );
+  } else {
     // auto-cache static assets on first completed map
     const allMaps = await getCachedTileMaps();
 
@@ -383,8 +425,6 @@ async function downloadTiles(
         // not critical
       }
     }
-
-    dispatch(cacheTilesComplete({ id }));
 
     const cm = await loadCachedMapsMessages(language);
 
@@ -441,6 +481,7 @@ export const cacheTilesStartProcessor: Processor<typeof cacheTilesStart> = {
           action.payload,
           dispatch,
           getState().l10n.language,
+          getState().auth.user,
           abortController,
         );
       })
@@ -566,6 +607,7 @@ export const cachedMapEditedProcessor: Processor<typeof cachedMapEdited> = {
       pruned,
       dispatch,
       getState().l10n.language,
+      getState().auth.user,
       abortController,
     ).catch((err: unknown) => {
       if (err instanceof DOMException && err.name === 'AbortError') {
@@ -594,7 +636,12 @@ export const cacheTilesRestartProcessor: Processor<typeof cacheTilesRestart> = {
       return;
     }
 
-    downloadTiles(meta, dispatch, getState().l10n.language).catch((err) => {
+    downloadTiles(
+      meta,
+      dispatch,
+      getState().l10n.language,
+      getState().auth.user,
+    ).catch((err) => {
       if (err instanceof DOMException && err.name === 'AbortError') {
         return;
       }

--- a/src/features/cachedMaps/sourceLayer.ts
+++ b/src/features/cachedMaps/sourceLayer.ts
@@ -1,0 +1,82 @@
+import type { User } from '@features/auth/model/types.js';
+import { isPremium } from '@features/premium/premium.js';
+import {
+  type CustomLayerDef,
+  integratedLayerDefs,
+} from '@shared/mapDefinitions.js';
+
+/** What a cached map takes from the layer it was made from while online. */
+export type SourceLayerEnvelope = {
+  minZoom: number | undefined;
+  maxNativeZoom: number | undefined;
+  premiumFromZoom: number | undefined;
+};
+
+function findSourceLayerDef(
+  sourceType: string,
+  customLayers: CustomLayerDef[],
+) {
+  return (
+    integratedLayerDefs.find((def) => def.type === sourceType) ??
+    customLayers.find((def) => def.type === sourceType)
+  );
+}
+
+/**
+ * The zoom range and premium gate a cached map wears while it can reach the
+ * network: those of its source layer, so that browsing past what was downloaded
+ * behaves exactly as the layer itself would — deeper zooms and a checkerboard
+ * where they are premium. `undefined` when the layer is no longer in the
+ * registry (a deleted custom layer), leaving the map to stand on its own range.
+ *
+ * Every key is present, `undefined` included: the result is spread over the
+ * map's own metadata, where a missing key would let the downloaded range through
+ * instead of lifting it.
+ */
+export function sourceLayerEnvelope(
+  sourceType: string,
+  customLayers: CustomLayerDef[],
+): SourceLayerEnvelope | undefined {
+  const def = findSourceLayerDef(sourceType, customLayers);
+
+  if (!def) {
+    return undefined;
+  }
+
+  return {
+    minZoom: def.minZoom,
+    maxNativeZoom: 'maxNativeZoom' in def ? def.maxNativeZoom : undefined,
+    premiumFromZoom: 'premiumFromZoom' in def ? def.premiumFromZoom : undefined,
+  };
+}
+
+/**
+ * The deepest zoom a cached map of `sourceType` may be given for this user, or
+ * `undefined` when the source layer gates nothing.
+ *
+ * Premium zooms are kept out of the download itself, not merely out of the view:
+ * tiles on disk are shown offline whatever the layer says, so downloading them
+ * would hand out a permanent copy of what the checkerboard is there to sell.
+ */
+export function premiumZoomLimit(
+  sourceType: string,
+  user: Pick<User, 'premiumExpiration'> | null,
+): number | undefined {
+  if (isPremium(user)) {
+    return undefined;
+  }
+
+  const def = integratedLayerDefs.find((def) => def.type === sourceType);
+
+  if (!def?.premiumFromZoom) {
+    return undefined;
+  }
+
+  // a layer that renders a zoom deeper than it is asked for reaches its premium
+  // tiles a zoom earlier, as Layers.tsx accounts for
+  return (
+    def.premiumFromZoom -
+    ('scaleWithDpi' in def && def.scaleWithDpi ? 1 : 0) -
+    1
+  );
+}

--- a/src/features/cachedMaps/translations/CachedMapsMessages.ts
+++ b/src/features/cachedMaps/translations/CachedMapsMessages.ts
@@ -22,4 +22,7 @@ export type CachedMapsMessages = {
   activate: string;
   focus: string;
   namePrefix: string;
+  premiumZoomHint: string;
+  premiumWiden: string;
+  premiumSkipped: string;
 };

--- a/src/features/cachedMaps/translations/en.messages.tsx
+++ b/src/features/cachedMaps/translations/en.messages.tsx
@@ -32,6 +32,12 @@ const en: CachedMapsMessages = {
   activate: 'Activate',
   focus: 'Zoom to area',
   namePrefix: 'Offline',
+  premiumZoomHint:
+    "This layer's deepest zoom levels are premium. An offline map keeps its tiles for good and shows them with no connection, so downloading those levels needs premium access.",
+  premiumWiden:
+    'This map reaches premium zoom levels. Without premium access it can be made smaller, but not larger — enlarging it would download premium tiles anew.',
+  premiumSkipped:
+    'The deepest zoom levels of this map are premium and were not downloaded, so it stays marked incomplete.',
 };
 
 export default en;

--- a/src/features/cachedMaps/translations/sk.template.tsx
+++ b/src/features/cachedMaps/translations/sk.template.tsx
@@ -33,6 +33,12 @@ const sk: DeepPartialWithRequiredObjects<CachedMapsMessages> = {
   activate: 'Aktivovať',
   focus: 'Priblížiť na oblasť',
   namePrefix: 'Offline',
+  premiumZoomHint:
+    'Najpodrobnejšie priblíženia tejto vrstvy sú prémiové. Offline mapa si dlaždice ponecháva natrvalo a zobrazuje ich aj bez pripojenia, takže na ich stiahnutie je potrebný prémiový prístup.',
+  premiumWiden:
+    'Táto mapa siaha do prémiových priblížení. Bez prémiového prístupu ju možno zmenšiť, nie však zväčšiť — zväčšením by sa nanovo stiahli prémiové dlaždice.',
+  premiumSkipped:
+    'Najpodrobnejšie priblíženia tejto mapy sú prémiové a nestiahli sa, takže mapa zostáva označená ako nekompletná.',
 };
 
 export default sk;

--- a/src/features/elevationChart/components/ElevationInfo.tsx
+++ b/src/features/elevationChart/components/ElevationInfo.tsx
@@ -10,6 +10,7 @@ import {
   integratedLayerDefs,
   isTileLayerDef,
 } from '@shared/mapDefinitions.js';
+import { pickSubdomain } from '@shared/tileUrl.js';
 import type { LatLon } from '@shared/types/common.js';
 import { Fragment, useCallback, useMemo } from 'react';
 import { Alert, Button, Form, InputGroup } from 'react-bootstrap';
@@ -52,6 +53,7 @@ export function ElevationInfo({
     url,
     maxNativeZoom,
     extraScales = [],
+    subdomains,
   }: IsTileLayerDef) {
     const [scale] = [1, ...extraScales]
       .map((scale) => [scale, Math.abs(devicePixelRatio - scale)] as const)
@@ -69,7 +71,8 @@ export function ElevationInfo({
         .replace('{x}', String(x))
         .replace('{y}', String(y))
         .replace('{z}', String(z))
-        .replace('{s}', 'a') + (scale !== 1 ? `@${scale}x` : '')
+        .replace('{s}', pickSubdomain(subdomains)) +
+      (scale !== 1 ? `@${scale}x` : '')
     );
   }
 

--- a/src/shared/hooks/useTilesSizeEstimate.ts
+++ b/src/shared/hooks/useTilesSizeEstimate.ts
@@ -5,6 +5,8 @@ const DEBOUNCE = 700;
 
 export type TilesSizeEstimateParams = {
   urlTemplate: string | undefined;
+  /** The `{s}` host to sample from; see `pickSubdomain`. */
+  subdomain?: string;
   bbox: [number, number, number, number] | undefined;
   minZoom: number;
   maxZoom: number;
@@ -34,6 +36,7 @@ export type TilesSizeEstimate = {
  */
 export function useTilesSizeEstimate({
   urlTemplate,
+  subdomain,
   bbox,
   minZoom,
   maxZoom,
@@ -77,6 +80,7 @@ export function useTilesSizeEstimate({
     const timeout = setTimeout(() => {
       sampleTilesSize({
         urlTemplate,
+        subdomain,
         bbox: bboxKey.split(',').map(Number) as [
           number,
           number,
@@ -113,7 +117,7 @@ export function useTilesSizeEstimate({
 
       abortController.abort();
     };
-  }, [enabled, urlTemplate, bboxKey, minZoom, maxZoom, scale, key]);
+  }, [enabled, urlTemplate, subdomain, bboxKey, minZoom, maxZoom, scale, key]);
 
   const bytesPerTile = sample?.key === key ? sample.bytesPerTile : undefined;
 

--- a/src/shared/tileSizeSampler.ts
+++ b/src/shared/tileSizeSampler.ts
@@ -39,6 +39,8 @@ export type TileSizeEstimate = {
 
 export type SampleTilesSizeParams = {
   urlTemplate: string;
+  /** The `{s}` host to sample from; see `pickSubdomain`. */
+  subdomain?: string;
   bbox: [number, number, number, number];
   minZoom: number;
   maxZoom: number;
@@ -54,6 +56,7 @@ export type SampleTilesSizeParams = {
  */
 export async function sampleTilesSize({
   urlTemplate,
+  subdomain,
   bbox,
   minZoom,
   maxZoom,
@@ -72,7 +75,7 @@ export async function sampleTilesSize({
             : SAMPLES_AT_OTHER_ZOOMS,
         ).map(async ([x, y]) => {
           const url = withTileScale(
-            buildTileUrl(urlTemplate, x, y, range.zoom),
+            buildTileUrl(urlTemplate, x, y, range.zoom, subdomain),
             scale,
           );
 

--- a/src/shared/tileUrl.ts
+++ b/src/shared/tileUrl.ts
@@ -1,14 +1,28 @@
+/**
+ * The subdomain a fetched tile is asked from. `{s}` exists to spread a map view
+ * over several hosts, which a fetch one tile at a time has no use for — but the
+ * name still has to resolve, and not every layer's subdomains are letters.
+ */
+export function pickSubdomain(
+  subdomains: string | string[] | undefined,
+): string {
+  return (
+    (typeof subdomains === 'string' ? subdomains[0] : subdomains?.[0]) ?? 'a'
+  );
+}
+
 export function buildTileUrl(
   urlTemplate: string,
   x: number,
   y: number,
   z: number,
+  subdomain = 'a',
 ): string {
   return urlTemplate
     .replace('{x}', String(x))
     .replace('{y}', String(y))
     .replace('{z}', String(z))
-    .replace('{s}', 'a');
+    .replace('{s}', subdomain);
 }
 
 /**

--- a/src/static/llms.txt
+++ b/src/static/llms.txt
@@ -358,6 +358,8 @@ The recording is also shown as a red line on the map with its newest fix marked;
 
 Caches selected map areas (tiles) in the browser for offline use. (This is different from "Offline maps export", which produces a downloadable MBTiles/SQLiteDB file.)
 
+A cached map is not limited to what it holds. While there is a connection it behaves as the layer it was made from: it takes that layer's zoom range and its premium gate, and any tile it doesn't have — outside its area, deeper than it was downloaded, or not downloaded yet — is fetched from that layer's own server. Such tiles are only displayed, never added to the cached map. Without a connection the map falls back to being just what was downloaded: its own area and zoom range, with the deepest cached level scaled up beyond it.
+
 The manager modal lists already-cached offline maps with their zoom range, tile count, scale, size and status (Ready, or incomplete with a percentage), and has buttons to modify, delete, and **Add offline map**. A ready map has an **Activate** button that switches the map layer on and zooms to its area; a map that is still downloading offers **Zoom to area** instead. A running download can be **Stop**ped, which halts it and keeps whatever has been cached so far; an incomplete map then offers **Resume**, which fetches only the tiles it is missing. **Delete** discards the map altogether and is available whether or not it is downloading.
 
 The "Cache map for offline use" form lets the user choose:
@@ -365,7 +367,7 @@ The "Cache map for offline use" form lets the user choose:
 - the map (layer) to cache — tile layers only; WMS layers cannot be cached
 - the area: current visible area, or a rectangle drawn on the map
 - a name
-- the zoom range
+- the zoom range. For a layer whose deepest zooms are premium, a non-premium user's range stops just short of them and a gem beside the field says why: cached tiles are kept for good and are shown with no connection, where no checkerboard applies, so downloading those levels needs premium access. Browsing them online is unaffected — the cached map shows the same checkerboard there as the source layer does.
 - the scale (1×, 2×, … — only for layers that offer hi-DPI tiles; defaults to what the current screen displays). A cached map holds exactly one scale and is always drawn at it, regardless of the screen and of the resolution/feature-size preferences.
 - whether to show the cached map in the menu and/or toolbar
 

--- a/src/sw/sw.ts
+++ b/src/sw/sw.ts
@@ -2,8 +2,10 @@
 
 import {
   CACHED_TILE_PATH_PREFIX,
-  parseCachedTileMapId,
+  parseCachedTilePath,
 } from '@features/cachedMaps/cachedTileUrl.js';
+import { pickSubdomain } from '@shared/tileUrl.js';
+import { get } from 'idb-keyval';
 
 declare const self: ServiceWorkerGlobalScope;
 
@@ -21,6 +23,18 @@ const SCALE_SUFFIX_RE = /@\d+(?:\.\d+)?x$/;
 
 // the scales any layer offers, cheapest lookup first
 const TILE_SCALES = [1, 2, 3, 4];
+
+const CACHED_TILE_MAPS_KEY = 'cachedTileMaps';
+
+// how soon an unknown map id may send us back to the database
+const RELOAD_MS = 5000;
+
+/** As much of a cached map's metadata as reaching its tile server takes. */
+type CachedTileMapMeta = {
+  type: string;
+  url: string;
+  subdomains?: string | string[];
+};
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
@@ -90,12 +104,60 @@ async function serveStaticAsset(event: FetchEvent): Promise<Response> {
   }
 }
 
-async function serveCachedTile(event: FetchEvent): Promise<Response> {
-  const mapId = parseCachedTileMapId(new URL(event.request.url).pathname);
+/**
+ * The origin a cached map's tiles came from, keyed by map id, `null` for a map
+ * whose template gives none. A map's id is random and its source layer can't be
+ * changed once it exists, so an entry can never go stale — only an id that isn't
+ * in the table yet reads the database, which is what picks up a map made since.
+ */
+const tileOrigins = new Map<string, string | null>();
 
-  if (!mapId) {
+let tileOriginsReadAt = 0;
+
+async function tileOrigin(mapId: string): Promise<string | undefined> {
+  // An id that isn't in the table is either a map made since the last read or
+  // one that no longer exists, and only a read tells the two apart — so read
+  // again, but no more often than this, lest a pan over a map whose metadata is
+  // gone open a transaction per tile.
+  if (!tileOrigins.has(mapId) && Date.now() - tileOriginsReadAt > RELOAD_MS) {
+    tileOriginsReadAt = Date.now();
+
+    try {
+      const metas =
+        (await get<CachedTileMapMeta[]>(CACHED_TILE_MAPS_KEY)) ?? [];
+
+      for (const { type, url, subdomains } of metas) {
+        try {
+          // `{s}` resolved as the download resolves it: it asked one host only,
+          // so that is the one the tiles are known to have come from
+          tileOrigins.set(
+            type,
+            new URL(url.replace('{s}', pickSubdomain(subdomains))).origin,
+          );
+        } catch {
+          // A map whose url template won't parse doesn't fall through — and is
+          // remembered as such, so it doesn't re-read the table per tile.
+          tileOrigins.set(type, null);
+        }
+      }
+    } catch {
+      return undefined;
+    }
+  }
+
+  return tileOrigins.get(mapId) ?? undefined;
+}
+
+async function serveCachedTile(event: FetchEvent): Promise<Response> {
+  const url = new URL(event.request.url);
+
+  const parsed = parseCachedTilePath(url.pathname);
+
+  if (!parsed) {
     return new Response(null, { status: 404 });
   }
+
+  const { mapId } = parsed;
 
   const cache = await caches.open(`${TILE_CACHE_PREFIX}${mapId}`);
 
@@ -111,10 +173,10 @@ async function serveCachedTile(event: FetchEvent): Promise<Response> {
   // A map holds exactly one `@Nx` variant. Should the request ask for another
   // one — a map whose metadata records no scale, viewed on a screen of a
   // different DPI — serve the variant that is there instead of an error tile.
-  const url = event.request.url.replace(SCALE_SUFFIX_RE, '');
+  const bareUrl = event.request.url.replace(SCALE_SUFFIX_RE, '');
 
   for (const scale of TILE_SCALES) {
-    const alt = scale === 1 ? url : `${url}@${scale}x`;
+    const alt = scale === 1 ? bareUrl : `${bareUrl}@${scale}x`;
 
     if (alt === event.request.url) {
       continue;
@@ -124,6 +186,29 @@ async function serveCachedTile(event: FetchEvent): Promise<Response> {
 
     if (altCached) {
       return altCached;
+    }
+  }
+
+  // Nothing stored for this tile: the map is being browsed outside the area it
+  // covers, or its download hasn't reached here. Ask the map's own tile server,
+  // so a cached map isn't a walled garden while there is a connection. The
+  // answer is not written back — the map stays exactly the artifact that was
+  // downloaded.
+  const origin = await tileOrigin(mapId);
+
+  if (origin) {
+    try {
+      return await fetch(`${origin}${parsed.path}${url.search}`, {
+        // A tile <img> without `crossOrigin` asks in no-cors mode, and an
+        // opaque answer is both returnable to it and free of any need for the
+        // source layer to send CORS headers. One that does set `crossOrigin`
+        // would refuse an opaque response, so it is passed through as-is.
+        mode: event.request.mode === 'cors' ? 'cors' : 'no-cors',
+        // as downloadTiles does, for providers that authenticate by `Referer`
+        referrerPolicy: 'strict-origin-when-cross-origin',
+      });
+    } catch {
+      // offline — draw the error tile, as before
     }
   }
 


### PR DESCRIPTION
Closes #1004 (part 3 of 3 split out of #992).

## Network fall-through

`serveCachedTile` answered `404` for any tile a cached map did not hold, so panning just outside the downloaded area drew error tiles on a perfect connection.

The worker now falls through to the map's own tile server on a miss. The upstream URL comes from the origin of the map's `url` template — read from the metadata in IndexedDB, `{s}` resolved the way the download resolves it — plus the path below `/__cached__/<id>`, which is the source layer's own path since `toCachedLayerUrl` replaces nothing but the origin. **Nothing is written back**; the map stays exactly the artifact that was downloaded. A failed fetch keeps the old `404`, so offline behaves as before.

The id → origin table is memoised in the worker with no invalidation: a map's id is random and its layer cannot change after creation, so an entry cannot go stale. Only an unknown id re-reads, and no more than once every 5 s.

## Online, a cached map is its source layer

Zoom range and premium gate are taken from the source layer whenever the network is reachable, so browsing past what was downloaded behaves as the layer itself would — deeper zooms, the layer still visible when you zoom out, and the checkerboard where the zooms are premium. Offline it reverts to the downloaded artifact: its own range, upscaling the deepest level it holds.

## Premium zooms

A downloaded tile is shown offline whatever the layer says, where no checkerboard applies — so the gate cannot live in the renderer alone. `downloadTiles` is the single place premium zooms are refused, for every path that reaches it: a fresh download, a **Resume**, or an edit of a map whose range outlived the premium access that earned it. `user` is a required parameter there, so a new call site cannot quietly skip the check.

The form matches: the zoom field stops short of the premium levels (with a gem explaining why), and a map already reaching past them can be shrunk or renamed but not enlarged. A pass that stops short raises a toast and leaves the map marked incomplete, which is true.

## Subdomain fix (separate commit)

`buildTileUrl` substituted `{s}` with the literal `a`. Layer **S** (Esri) declares `['server', 'services']`, so every tile went to the non-existent `a.arcgisonline.com` — that layer could never be cached at all, and the elevation chart's tile preview was broken for it. Cache keys are unaffected, as `toCachedLayerUrl` strips the host.

## Known trade-offs

- The online/offline envelope is chosen by `navigator.onLine`. On a connected-but-dead network (captive portal, radio up with no data) the map takes the source's deeper `maxNativeZoom` and shows error tiles past the downloaded depth instead of upscaled cached tiles.
- After premium lapses, the checkerboard covers premium tiles the user had already downloaded while online; offline they still render in full.

Both follow directly from wanting the checkerboard shown online.

## Testing

The service worker is registered only in production builds, so none of this can be exercised with `pnpm start`. Worth checking after deploy: panning outside a cached area online; going offline and confirming the area still works while outside it goes blank; caching layer S now that it is possible; and, as a non-premium user, the capped zoom field and the shrink-but-not-grow rule on **Modify**.

`tsc`, biome and a full `rspack build` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)