### PR TITLE
feat(mapFeaturesExport): show the export as running instead of nothing

### DIFF
--- a/src/features/mapFeaturesExport/components/MapFeaturesExportModal.tsx
+++ b/src/features/mapFeaturesExport/components/MapFeaturesExportModal.tsx
@@ -22,6 +22,7 @@ import {
   ButtonGroup,
   Form,
   Modal,
+  Spinner,
   ToggleButton,
 } from 'react-bootstrap';
 import {
@@ -36,6 +37,7 @@ import { SiGarmin } from 'react-icons/si';
 import { useDispatch } from 'react-redux';
 import {
   EXPORT_FORMAT_LABELS,
+  EXPORT_PROGRESS_ID,
   type Exportable,
   type ExportElevation,
   ExportElevationSchema,
@@ -96,6 +98,21 @@ export default function MapFeaturesExportModal({ show }: Props): ReactElement {
   const selectedExportable = useSelectedExportable();
 
   const selection = useAppSelector((state) => state.main.selection);
+
+  // The export runs in a processor, so its progress id is what tells the form it
+  // is busy — but that id is global and says nothing about who started it, so it
+  // only counts once this modal has. Close stays available and abandons the
+  // export: one that is filling elevation is aborted outright (`setActiveModal`
+  // cancels the request), while one that isn't carries on and lands its file
+  // with the modal already gone — and reopening then gives a usable form rather
+  // than one inert until that export settles.
+  const [exportStarted, setExportStarted] = useState(false);
+
+  const exportInProgress = useAppSelector((state) =>
+    state.progress.includes(EXPORT_PROGRESS_ID),
+  );
+
+  const exporting = exportStarted && exportInProgress;
 
   const userHasGarmin = useAppSelector((state) =>
     state.auth.user?.authProviders.includes('garmin'),
@@ -187,6 +204,8 @@ export default function MapFeaturesExportModal({ show }: Props): ReactElement {
       if (!exportables) {
         return;
       }
+
+      setExportStarted(true);
 
       const exportAction = exportMapFeatures({
         type,
@@ -356,260 +375,265 @@ export default function MapFeaturesExportModal({ show }: Props): ReactElement {
         </Modal.Header>
 
         <Modal.Body>
-          <Alert variant="warning">{em?.licenseAlert}</Alert>
+          <fieldset disabled={exporting}>
+            <Alert variant="warning">{em?.licenseAlert}</Alert>
 
-          <Form.Group controlId="target" className="mb-3">
-            <Form.Label>{em?.target}</Form.Label>
-
-            <div>
-              <ButtonGroup vertical={!sm}>
-                {ExportTargetSchema.options
-                  .filter(
-                    (exportTarget) => exportTarget !== 'share' || shareable,
-                  )
-                  .map((exportTarget) => (
-                    <ToggleButton
-                      id={exportTarget}
-                      key={exportTarget}
-                      type="radio"
-                      variant="outline-primary"
-                      checked={target === exportTarget}
-                      value={exportTarget}
-                      onChange={setTarget}
-                      disabled={!initExportables}
-                    >
-                      {
-                        {
-                          download: (
-                            <>
-                              <FaDownload /> {em?.download}
-                            </>
-                          ),
-                          share: (
-                            <>
-                              <FaShareAlt /> {em?.share}
-                            </>
-                          ),
-                          gdrive: (
-                            <>
-                              <FaGoogle /> Google Drive
-                            </>
-                          ),
-                          dropbox: (
-                            <>
-                              <FaDropbox /> Dropbox
-                            </>
-                          ),
-                          garmin: (
-                            <>
-                              {/* A wordmark in a square 24×24 viewBox: it needs
-                                  the scale-up to read, and the negative margin
-                                  (in the scaled em, so it tracks the size) to
-                                  give back the empty box around it. */}
-                              <SiGarmin
-                                title="Garmin"
-                                style={{
-                                  fontSize: '400%',
-                                  marginBlock: '-0.375em',
-                                }}
-                              />
-                              &ensp;
-                              <ExperimentalFunction />
-                            </>
-                          ),
-                        }[exportTarget]
-                      }
-                    </ToggleButton>
-                  ))}
-              </ButtonGroup>
-            </div>
-
-            {shareNote && (
-              <Form.Text muted className="d-block mt-1">
-                {shareNote}
-              </Form.Text>
-            )}
-          </Form.Group>
-
-          {isGarmin ? (
-            <>
-              <Form.Group controlId="courseName" className="mb-3">
-                <Form.Label>{em?.garmin.courseName}</Form.Label>
-
-                <Form.Control
-                  value={name}
-                  onChange={(e) => setName(e.currentTarget.value)}
-                />
-              </Form.Group>
-
-              <Form.Group controlId="description" className="mb-3">
-                <Form.Label>{em?.garmin.description}</Form.Label>
-
-                <Form.Control
-                  as="textarea"
-                  rows={2}
-                  value={description}
-                  onChange={(e) => setDescription(e.currentTarget.value)}
-                />
-              </Form.Group>
-
-              {/* Too many options with too long labels for a joined group. */}
-              <Form.Group controlId="activityType" className="mb-3">
-                <Form.Label>{em?.garmin.activityType}</Form.Label>
-
-                <Form.Select
-                  value={activity}
-                  onChange={(e) => setActivity(e.currentTarget.value)}
-                >
-                  <option value="" />
-
-                  {garminActivityTypes.map(([value, labelKey]) => (
-                    <option key={value} value={value}>
-                      {em?.garmin.at[labelKey]}
-                    </option>
-                  ))}
-                </Form.Select>
-              </Form.Group>
-            </>
-          ) : (
-            <Form.Group controlId="format" className="mb-3">
-              <Form.Label>{em?.format}</Form.Label>
-
-              <div>
-                <ButtonGroup>
-                  {ExportTypeSchema.options.map((exportType) => (
-                    <ToggleButton
-                      id={exportType}
-                      key={exportType}
-                      type="radio"
-                      variant="outline-primary"
-                      value={exportType}
-                      checked={type === exportType}
-                      onChange={setType}
-                      disabled={!exportables.length}
-                    >
-                      {EXPORT_FORMAT_LABELS[exportType]}
-                    </ToggleButton>
-                  ))}
-                </ButtonGroup>
-              </div>
-            </Form.Group>
-          )}
-
-          <Form.Group controlId="download" className="mb-3">
-            <Form.Label>{m?.general.export}</Form.Label>
-
-            {target === 'garmin' ? (
-              <>
-                <div className="d-flex flex-wrap gap-2">
-                  {exportableDefinitions
-                    .filter(([, , garmin]) => garmin)
-                    .map(([type, Icon]) => {
-                      const value = garminExportables?.[type];
-
-                      const error =
-                        typeof value === 'string' ? value : undefined;
-
-                      const selected = exportables.includes(`|${type}|`);
-
-                      return (
-                        <ToggleButton
-                          key={type}
-                          id={`chk-${type}`}
-                          name="exportable"
-                          type="radio"
-                          variant={
-                            selected && error
-                              ? 'outline-danger'
-                              : 'outline-primary'
-                          }
-                          value={type}
-                          checked={selected}
-                          // only truly empty options are unavailable; options
-                          // with a problem stay selectable so the reason can be
-                          // shown on demand
-                          disabled={!value}
-                          onChange={() => handleCheckboxChange(type)}
-                        >
-                          <Icon /> {em?.what[type]}
-                        </ToggleButton>
-                      );
-                    })}
-                </div>
-
-                {exportableDefinitions
-                  .filter(
-                    ([type, , garmin]) =>
-                      garmin &&
-                      exportables.includes(`|${type}|`) &&
-                      typeof garminExportables?.[type] === 'string',
-                  )
-                  .map(([type, Icon]) => (
-                    <Form.Text key={type} className="d-block text-danger mt-2">
-                      <Icon /> {em?.what[type]}{' '}
-                      {garminExportables?.[type] as string}
-                    </Form.Text>
-                  ))}
-              </>
-            ) : (
-              <>
-                {selectedExportable && (
-                  <Form.Check
-                    type="switch"
-                    id="onlySelected"
-                    className="mb-2"
-                    label={em?.onlySelected}
-                    checked={onlySelected}
-                    onChange={(e) => setOnlySelected(e.currentTarget.checked)}
-                  />
-                )}
-
-                {!effectiveOnlySelected && (
-                  <ExportablesSelector
-                    value={exportables}
-                    available={initExportables}
-                    onChange={setExportables}
-                  />
-                )}
-              </>
-            )}
-
-            {!effectiveOnlySelected && (
-              <Form.Text muted className="d-block mt-1">
-                {em?.disabledAlert}
-              </Form.Text>
-            )}
-          </Form.Group>
-
-          {!isGarmin && (
-            <Form.Group controlId="elevation" className="mb-3">
-              <Form.Label>{em?.elevation.label}</Form.Label>
+            <Form.Group controlId="target" className="mb-3">
+              <Form.Label>{em?.target}</Form.Label>
 
               <div>
                 <ButtonGroup vertical={!sm}>
-                  {ExportElevationSchema.options.map((option) => (
-                    <ToggleButton
-                      id={`ele-${option}`}
-                      key={option}
-                      type="radio"
-                      variant="outline-primary"
-                      value={option}
-                      checked={effectiveElevation === option}
-                      onChange={setElevation}
-                      // The whole control is off when nothing selected can carry
-                      // elevation; "Override all" is off when nothing recorded
-                      // can be overridden (it would equal "Fill missing").
-                      disabled={
-                        !canElevate || (option === 'all' && !hasRecorded)
-                      }
-                    >
-                      {em?.elevation[option]}
-                    </ToggleButton>
-                  ))}
+                  {ExportTargetSchema.options
+                    .filter(
+                      (exportTarget) => exportTarget !== 'share' || shareable,
+                    )
+                    .map((exportTarget) => (
+                      <ToggleButton
+                        id={exportTarget}
+                        key={exportTarget}
+                        type="radio"
+                        variant="outline-primary"
+                        checked={target === exportTarget}
+                        value={exportTarget}
+                        onChange={setTarget}
+                        disabled={!initExportables}
+                      >
+                        {
+                          {
+                            download: (
+                              <>
+                                <FaDownload /> {em?.download}
+                              </>
+                            ),
+                            share: (
+                              <>
+                                <FaShareAlt /> {em?.share}
+                              </>
+                            ),
+                            gdrive: (
+                              <>
+                                <FaGoogle /> Google Drive
+                              </>
+                            ),
+                            dropbox: (
+                              <>
+                                <FaDropbox /> Dropbox
+                              </>
+                            ),
+                            garmin: (
+                              <>
+                                {/* A wordmark in a square 24×24 viewBox: it needs
+                                  the scale-up to read, and the negative margin
+                                  (in the scaled em, so it tracks the size) to
+                                  give back the empty box around it. */}
+                                <SiGarmin
+                                  title="Garmin"
+                                  style={{
+                                    fontSize: '400%',
+                                    marginBlock: '-0.375em',
+                                  }}
+                                />
+                                &ensp;
+                                <ExperimentalFunction />
+                              </>
+                            ),
+                          }[exportTarget]
+                        }
+                      </ToggleButton>
+                    ))}
                 </ButtonGroup>
               </div>
+
+              {shareNote && (
+                <Form.Text muted className="d-block mt-1">
+                  {shareNote}
+                </Form.Text>
+              )}
             </Form.Group>
-          )}
+
+            {isGarmin ? (
+              <>
+                <Form.Group controlId="courseName" className="mb-3">
+                  <Form.Label>{em?.garmin.courseName}</Form.Label>
+
+                  <Form.Control
+                    value={name}
+                    onChange={(e) => setName(e.currentTarget.value)}
+                  />
+                </Form.Group>
+
+                <Form.Group controlId="description" className="mb-3">
+                  <Form.Label>{em?.garmin.description}</Form.Label>
+
+                  <Form.Control
+                    as="textarea"
+                    rows={2}
+                    value={description}
+                    onChange={(e) => setDescription(e.currentTarget.value)}
+                  />
+                </Form.Group>
+
+                {/* Too many options with too long labels for a joined group. */}
+                <Form.Group controlId="activityType" className="mb-3">
+                  <Form.Label>{em?.garmin.activityType}</Form.Label>
+
+                  <Form.Select
+                    value={activity}
+                    onChange={(e) => setActivity(e.currentTarget.value)}
+                  >
+                    <option value="" />
+
+                    {garminActivityTypes.map(([value, labelKey]) => (
+                      <option key={value} value={value}>
+                        {em?.garmin.at[labelKey]}
+                      </option>
+                    ))}
+                  </Form.Select>
+                </Form.Group>
+              </>
+            ) : (
+              <Form.Group controlId="format" className="mb-3">
+                <Form.Label>{em?.format}</Form.Label>
+
+                <div>
+                  <ButtonGroup>
+                    {ExportTypeSchema.options.map((exportType) => (
+                      <ToggleButton
+                        id={exportType}
+                        key={exportType}
+                        type="radio"
+                        variant="outline-primary"
+                        value={exportType}
+                        checked={type === exportType}
+                        onChange={setType}
+                        disabled={!exportables.length}
+                      >
+                        {EXPORT_FORMAT_LABELS[exportType]}
+                      </ToggleButton>
+                    ))}
+                  </ButtonGroup>
+                </div>
+              </Form.Group>
+            )}
+
+            <Form.Group controlId="download" className="mb-3">
+              <Form.Label>{m?.general.export}</Form.Label>
+
+              {target === 'garmin' ? (
+                <>
+                  <div className="d-flex flex-wrap gap-2">
+                    {exportableDefinitions
+                      .filter(([, , garmin]) => garmin)
+                      .map(([type, Icon]) => {
+                        const value = garminExportables?.[type];
+
+                        const error =
+                          typeof value === 'string' ? value : undefined;
+
+                        const selected = exportables.includes(`|${type}|`);
+
+                        return (
+                          <ToggleButton
+                            key={type}
+                            id={`chk-${type}`}
+                            name="exportable"
+                            type="radio"
+                            variant={
+                              selected && error
+                                ? 'outline-danger'
+                                : 'outline-primary'
+                            }
+                            value={type}
+                            checked={selected}
+                            // only truly empty options are unavailable; options
+                            // with a problem stay selectable so the reason can be
+                            // shown on demand
+                            disabled={!value}
+                            onChange={() => handleCheckboxChange(type)}
+                          >
+                            <Icon /> {em?.what[type]}
+                          </ToggleButton>
+                        );
+                      })}
+                  </div>
+
+                  {exportableDefinitions
+                    .filter(
+                      ([type, , garmin]) =>
+                        garmin &&
+                        exportables.includes(`|${type}|`) &&
+                        typeof garminExportables?.[type] === 'string',
+                    )
+                    .map(([type, Icon]) => (
+                      <Form.Text
+                        key={type}
+                        className="d-block text-danger mt-2"
+                      >
+                        <Icon /> {em?.what[type]}{' '}
+                        {garminExportables?.[type] as string}
+                      </Form.Text>
+                    ))}
+                </>
+              ) : (
+                <>
+                  {selectedExportable && (
+                    <Form.Check
+                      type="switch"
+                      id="onlySelected"
+                      className="mb-2"
+                      label={em?.onlySelected}
+                      checked={onlySelected}
+                      onChange={(e) => setOnlySelected(e.currentTarget.checked)}
+                    />
+                  )}
+
+                  {!effectiveOnlySelected && (
+                    <ExportablesSelector
+                      value={exportables}
+                      available={initExportables}
+                      onChange={setExportables}
+                    />
+                  )}
+                </>
+              )}
+
+              {!effectiveOnlySelected && (
+                <Form.Text muted className="d-block mt-1">
+                  {em?.disabledAlert}
+                </Form.Text>
+              )}
+            </Form.Group>
+
+            {!isGarmin && (
+              <Form.Group controlId="elevation" className="mb-3">
+                <Form.Label>{em?.elevation.label}</Form.Label>
+
+                <div>
+                  <ButtonGroup vertical={!sm}>
+                    {ExportElevationSchema.options.map((option) => (
+                      <ToggleButton
+                        id={`ele-${option}`}
+                        key={option}
+                        type="radio"
+                        variant="outline-primary"
+                        value={option}
+                        checked={effectiveElevation === option}
+                        onChange={setElevation}
+                        // The whole control is off when nothing selected can carry
+                        // elevation; "Override all" is off when nothing recorded
+                        // can be overridden (it would equal "Fill missing").
+                        disabled={
+                          !canElevate || (option === 'all' && !hasRecorded)
+                        }
+                      >
+                        {em?.elevation[option]}
+                      </ToggleButton>
+                    ))}
+                  </ButtonGroup>
+                </div>
+              </Form.Group>
+            )}
+          </fieldset>
         </Modal.Body>
 
         <Modal.Footer>
@@ -617,12 +641,18 @@ export default function MapFeaturesExportModal({ show }: Props): ReactElement {
             type="submit"
             variant="primary"
             disabled={
+              exporting ||
               !exportables.length ||
               garminSelectedError ||
               (target === 'garmin' && (!name.trim() || !activity))
             }
           >
-            <FaFileExport /> {m?.general.export}
+            {exporting ? (
+              <Spinner as="span" size="sm" role="status" />
+            ) : (
+              <FaFileExport />
+            )}{' '}
+            {m?.general.export}
           </Button>
 
           <Button variant="dark" onClick={close}>

--- a/src/features/mapFeaturesExport/model/actions.ts
+++ b/src/features/mapFeaturesExport/model/actions.ts
@@ -44,6 +44,12 @@ export const ExportElevationSchema = z.enum(['none', 'missing', 'all']);
 
 export type ExportElevation = z.infer<typeof ExportElevationSchema>;
 
+/**
+ * Progress id the export processor holds for as long as the export runs. The
+ * export modal watches it to show its busy state.
+ */
+export const EXPORT_PROGRESS_ID = 'mapFeaturesExport';
+
 export const exportMapFeatures = createAction<{
   exportables: Exportable[];
   type: ExportType;

--- a/src/features/mapFeaturesExport/model/processors/exportMapFeaturesProcessor.ts
+++ b/src/features/mapFeaturesExport/model/processors/exportMapFeaturesProcessor.ts
@@ -1,10 +1,19 @@
+import { sendError } from '@app/store/middleware/globalErrorHandler.js';
 import type {
   Processor,
   ProcessorHandler,
 } from '@app/store/middleware/processorMiddleware.js';
+import {
+  startProgress,
+  stopProgress,
+} from '@features/progress/model/actions.js';
 import { trackMatomo } from '@shared/trackMatomo.js';
 import { loadMapFeaturesExportMessages } from '../../translations/loadMapFeaturesExportMessages.js';
-import { type ExportType, exportMapFeatures } from '../actions.js';
+import {
+  EXPORT_PROGRESS_ID,
+  type ExportType,
+  exportMapFeatures,
+} from '../actions.js';
 
 type HandlerModule = { default: ProcessorHandler<typeof exportMapFeatures> };
 
@@ -33,7 +42,7 @@ export const exportMapFeaturesProcessor: Processor<typeof exportMapFeatures> = {
   actionCreator: exportMapFeatures,
   id: 'mapFeaturesExport',
   handle: async (...params) => {
-    const { toastError } = params[0];
+    const { toastError, dispatch } = params[0];
 
     const { type, target, exportables } = params[0].action.payload;
 
@@ -48,6 +57,13 @@ export const exportMapFeaturesProcessor: Processor<typeof exportMapFeatures> = {
       }).toString(),
     ]);
 
+    dispatch(startProgress(EXPORT_PROGRESS_ID));
+
+    // A handler chunk that won't load — offline, or hashes from a past deploy —
+    // is the app failing to deliver itself rather than an export fault, and
+    // reporting it would add a ticket-id toast to a plain "reload me".
+    let loaded = false;
+
     try {
       const module =
         target === 'garmin'
@@ -57,9 +73,23 @@ export const exportMapFeaturesProcessor: Processor<typeof exportMapFeatures> = {
             )
           : await formatHandlers[type]();
 
-      return module.default(...params);
+      loaded = true;
+
+      return await module.default(...params);
     } catch (err) {
+      // `toastError` replaces the middleware's generic processor toast with the
+      // export's own, so the reporting the middleware would have done is done
+      // here. A cancelled export is not a failure.
+      if (
+        loaded &&
+        !(err instanceof DOMException && err.name === 'AbortError')
+      ) {
+        sendError({ kind: 'processor', error: err, action: params[0].action });
+      }
+
       await toastError(err, loadMapFeaturesExportMessages, 'exportError');
+    } finally {
+      dispatch(stopProgress(EXPORT_PROGRESS_ID));
     }
   },
 };

--- a/src/features/progress/model/reducer.ts
+++ b/src/features/progress/model/reducer.ts
@@ -10,7 +10,13 @@ export const progressReducer = createReducer(progressInitialState, (builder) =>
     .addCase(startProgress, (state, action) => {
       state.push(action.payload);
     })
-    .addCase(stopProgress, (state, action) =>
-      state.filter((pid) => pid !== action.payload),
-    ),
+    // Drops one entry, not every match: a named pid (one a component watches to
+    // know that particular operation is running) is held once per run, so two
+    // overlapping runs have to be counted rather than cleared by the first to
+    // finish. Random pids are unique, so for them this is the same removal.
+    .addCase(stopProgress, (state, action) => {
+      const i = state.indexOf(action.payload);
+
+      return i < 0 ? state : [...state.slice(0, i), ...state.slice(i + 1)];
+    }),
 );

--- a/src/static/llms.txt
+++ b/src/static/llms.txt
@@ -440,6 +440,8 @@ When a single map feature is selected (a drawing point/line/polygon, an object, 
 
 For the file/share/Google Drive/Dropbox targets an **Elevation** control chooses whether to fill elevation from the elevation API into exported points, lines and the planned route: *Keep recorded* (leave as-is), *Fill missing* (only coordinates lacking elevation), or *Override all* (replace every elevation). Polygons are always skipped.
 
+While the export runs its controls are disabled and a spinner replaces the icon on the export button. **Close** stays active: it gives up on the export — one that is filling elevation is abandoned outright, while one that is not carries on and downloads its file with the modal already gone.
+
 The target can be a downloaded file, the device share sheet, Google Drive, Dropbox, or Garmin Connect. **Share** hands the exported file to the operating system's share sheet (send it to a messenger, mail app, or a hiking app); it is offered only in browsers that let a page share files at all. Chromium-based browsers share no geo formats, so there the file travels as plain text with a `.txt` suffix appended to its name (`freemap-export-….gpx.txt`), which a note under the target explains. If the browser refuses to open the share sheet at all — an export slow enough to lose the click that asked for it — the file is downloaded instead and a message says so. Exporting a planned route to Garmin Connect as a course (experimental) requires a connected Garmin account and lets the user choose a course name and activity type (running, hiking, mountain biking, trail running, road/gravel cycling, other).
 
 ### Maps for GPS devices


### PR DESCRIPTION
Pressing **Export** in the map-data export modal left the form exactly as it was, so a slow export — filling elevation over a long track, packing photos into a KMZ, waiting on a Drive folder picker — read as a click that did nothing, and invited a second press on top of the first.

The form is now disabled with a spinner on the Export button for as long as the export runs, matching the map-to-document export modal.

## How the busy state is known

That export awaits its own call and holds the state locally; this one runs in a processor, so `exportMapFeaturesProcessor` holds a named progress id (`EXPORT_PROGRESS_ID`) and the modal watches `state.progress` for it. The id is global and says nothing about who started it, so it only counts once this modal has started an export itself — a modal reopened over an export left running by a Close comes up usable rather than inert.

**Close** stays available, and keeps abandoning the export as it always has: one filling elevation is aborted outright (`setActiveModal` is in `exportElevationCancelActions`), while one that is not carries on and downloads its file.

## Two supporting fixes

- **`stopProgress` drops one entry, not every match** — so two overlapping runs are counted rather than cleared by the first to finish. Reachable through the Garmin auth popup, which leaves the modal live while no export has started yet. Every other pid is a unique `Math.random()`, so for them this is the same removal.
- **The export handler is finally awaited** — which is what lets the progress id be released on every path. Its rejection used to escape the processor's own `catch` and surface as the generic `general.processorError`, leaving the localized `exportError` message unused; it now shows, and the `sendError` reporting the middleware would have done happens here instead. A handler chunk that won't load (offline, or hashes from a past deploy) stays unreported — that is the app failing to deliver itself rather than an export fault, and one ticket-id toast over a plain "reload me" is enough.

## Notes

- The large diff in `MapFeaturesExportModal.tsx` is almost entirely re-indentation from wrapping the body in `<fieldset disabled>`; `git diff -w` shows the real change.
- `llms.txt` gains the sentence its map-to-document-export counterpart already had.

## Test plan

- [x] `biome check` clean on all touched files
- [x] `tsc --noEmit` — no new errors (remaining ones are pre-existing CSS-module `TS4111` noise and the ungenerated gallery proto)
- [x] `vitest run src/features/mapFeaturesExport` — 10 passed
- [ ] Manual: export with *Fill missing* elevation over a long track → spinner + disabled form; Close mid-run abandons it
- [ ] Manual: Dropbox / Google Drive targets → spinner holds across the OAuth popup and folder picker
- [ ] Manual: reopen the modal during a running export → form usable

🤖 Generated with [Claude Code](https://claude.com/claude-code)