### PR TITLE
fix(elevationChart): say why a point elevation is missing instead of spinning

### DIFF
--- a/src/features/elevationChart/components/ElevationInfo.tsx
+++ b/src/features/elevationChart/components/ElevationInfo.tsx
@@ -39,6 +39,7 @@ export function ElevationInfo({
   loading,
   point,
   sources: reportedSources,
+  error,
   tileMessage,
   maslMessage,
 }: ElevationInfoProps) {
@@ -123,6 +124,7 @@ export function ElevationInfo({
         elevation={elevation}
         loading={loading}
         sources={reportedSources}
+        error={error}
         label={maslMessage}
       />
 

--- a/src/features/elevationChart/components/ElevationValue.tsx
+++ b/src/features/elevationChart/components/ElevationValue.tsx
@@ -7,7 +7,8 @@ import { useAppSelector } from '@shared/hooks/useAppSelector.js';
 import { useNumberFormat } from '@shared/hooks/useNumberFormat.js';
 import type { ReactElement } from 'react';
 import { Spinner } from 'react-bootstrap';
-import { FaInfoCircle } from 'react-icons/fa';
+import { FaExclamationTriangle, FaInfoCircle } from 'react-icons/fa';
+import { addError } from '@/translations/messagesInterface.js';
 import {
   elevationSourceNames,
   useElevationSources,
@@ -24,6 +25,12 @@ export type ElevationReading = {
    * API names none.
    */
   sources: string[];
+  /**
+   * Why the read failed. Shown in place of the value, so a failure that the
+   * rest of the toast survives (being offline, most of all) is answered here
+   * instead of by a danger toast beside it.
+   */
+  error?: unknown;
 };
 
 export type ElevationValueProps = ElevationReading & {
@@ -32,14 +39,16 @@ export type ElevationValueProps = ElevationReading & {
 };
 
 /**
- * The single-point elevation line: a spinner while it is read, an em dash where
- * the API has no data, otherwise the value with the terrain model behind it and
- * the premium offer of a finer one.
+ * The single-point elevation line: a spinner while it is read, a warning
+ * carrying the reason where the read failed, an em dash where the API has no
+ * data, otherwise the value with the terrain model behind it and the premium
+ * offer of a finer one.
  */
 export function ElevationValue({
   elevation,
   loading,
   sources: reportedSources,
+  error,
   label,
   className,
 }: ElevationValueProps): ReactElement | null {
@@ -67,7 +76,7 @@ export function ElevationValue({
   const sourceHint =
     ecm && sourceNames ? `${ecm.elevationSource}: ${sourceNames}` : undefined;
 
-  if (!loading && elevation === undefined) {
+  if (!loading && elevation === undefined && error === undefined) {
     return null;
   }
 
@@ -76,6 +85,18 @@ export function ElevationValue({
       {label}:{' '}
       {loading ? (
         <Spinner animation="border" size="sm" />
+      ) : error !== undefined ? (
+        <LongPressTooltip
+          label={
+            m && ecm ? addError(m, ecm.fetchError, error) : String(error ?? '')
+          }
+        >
+          {({ props }) => (
+            <span className="text-danger fm-cursor-help" {...props}>
+              <FaExclamationTriangle />
+            </span>
+          )}
+        </LongPressTooltip>
       ) : elevation == null ? (
         <span className="text-muted">—</span>
       ) : (

--- a/src/features/elevationChart/translations/ElevationChartMessages.ts
+++ b/src/features/elevationChart/translations/ElevationChartMessages.ts
@@ -5,4 +5,5 @@ export type ElevationChartMessages = {
   showWaypoints: string;
   settings: string;
   elevationSource: string;
+  fetchError: string;
 };

--- a/src/features/elevationChart/translations/en.messages.tsx
+++ b/src/features/elevationChart/translations/en.messages.tsx
@@ -7,6 +7,7 @@ const en: ElevationChartMessages = {
   showWaypoints: 'Show waypoints',
   settings: 'Elevation settings',
   elevationSource: 'Elevation data',
+  fetchError: 'Elevation could not be read',
 };
 
 export default en;

--- a/src/features/elevationChart/translations/sk.template.tsx
+++ b/src/features/elevationChart/translations/sk.template.tsx
@@ -8,6 +8,7 @@ const sk: DeepPartialWithRequiredObjects<ElevationChartMessages> = {
   showWaypoints: 'Zobraziť trasové body',
   settings: 'Nastavenia výškového profilu',
   elevationSource: 'Výškové dáta',
+  fetchError: 'Výšku sa nepodarilo načítať',
 };
 
 export default sk;

--- a/src/features/measurement/model/measurementProcessor.ts
+++ b/src/features/measurement/model/measurementProcessor.ts
@@ -10,6 +10,7 @@ import type { ElevationInfoBaseProps } from '@features/elevationChart/components
 import { loadMeasurementMessages } from '@features/measurement/translations/loadMeasurementMessages.js';
 import { toastsAdd } from '@features/toasts/model/actions.js';
 import { fetchElevations } from '@shared/elevation.js';
+import { isAbortError } from '@shared/isAbortError.js';
 import { isDrawTool } from '@shared/toolDefinitions.js';
 import { trackMatomo } from '@shared/trackMatomo.js';
 import type { LatLon } from '@shared/types/common.js';
@@ -84,6 +85,8 @@ export const measurementProcessor: Processor<typeof drawingMeasure> = {
           sources: [],
         };
 
+        let error: unknown;
+
         if (action.payload.elevation !== false) {
           dispatch(
             toastsAdd({
@@ -96,15 +99,26 @@ export const measurementProcessor: Processor<typeof drawingMeasure> = {
             }),
           );
 
-          // Through the shared fetch, so a single point is read the same way a
-          // profile is — and the readout's tooltip credits the model that
-          // actually answered.
-          [elevation] = await fetchElevations(
-            [[point.lat, point.lon]],
-            getState,
-            [drawingMeasure, clearMapFeatures],
-            sources,
-          );
+          try {
+            // Through the shared fetch, so a single point is read the same way a
+            // profile is — and the readout's tooltip credits the model that
+            // actually answered.
+            [elevation] = await fetchElevations(
+              [[point.lat, point.lon]],
+              getState,
+              [drawingMeasure, clearMapFeatures],
+              sources,
+            );
+          } catch (err) {
+            // The coordinates and the tile links stand without an elevation, so
+            // the failure is answered in the readout's own line rather than
+            // thrown at a danger toast beside a spinner that never stops.
+            if (isAbortError(err)) {
+              throw err;
+            }
+
+            error = err;
+          }
         }
 
         dispatch(
@@ -116,6 +130,7 @@ export const measurementProcessor: Processor<typeof drawingMeasure> = {
             messageParams: {
               ...toastParams,
               elevation,
+              error,
               sources: [...sources],
             },
             cancelType,

--- a/src/features/objects/model/objectDetailsProcessor.test.ts
+++ b/src/features/objects/model/objectDetailsProcessor.test.ts
@@ -243,8 +243,12 @@ describe('objectDetailsProcessor', () => {
     });
   });
 
-  it('stops the elevation spinner when the read fails', async () => {
-    fetchElevationsMock.mockRejectedValue(new Error('nope'));
+  it('answers a failed read in the elevation line, not with a spinner', async () => {
+    // The tags stand without an elevation, so the failure — being offline, most
+    // of all — is reported where the value would be.
+    const err = new Error('nope');
+
+    fetchElevationsMock.mockRejectedValue(err);
 
     const { dispatch, done } = run(
       state({}),
@@ -256,6 +260,7 @@ describe('objectDetailsProcessor', () => {
     expect(dispatch.mock.calls[1][0].payload.messageParams.elevation).toEqual({
       elevation: undefined,
       loading: false,
+      error: err,
       sources: [],
     });
   });

--- a/src/features/objects/model/objectDetailsProcessor.ts
+++ b/src/features/objects/model/objectDetailsProcessor.ts
@@ -175,6 +175,8 @@ export const objectDetailsProcessor: Processor = {
 
     let elevation: number | null | undefined;
 
+    let error: unknown;
+
     try {
       [elevation] = await fetchElevations(
         [[coords.lat, coords.lon]],
@@ -195,9 +197,9 @@ export const objectDetailsProcessor: Processor = {
         return;
       }
 
-      // The details themselves stand without it, so a failed read just drops
-      // the line instead of toasting an error over them.
-      elevation = undefined;
+      // The details themselves stand without it, so the failure is answered in
+      // the elevation's own line instead of toasting an error over them.
+      error = err;
     }
 
     // The subject can have moved on — or the toast be dismissed — while the read
@@ -210,6 +212,6 @@ export const objectDetailsProcessor: Processor = {
       return;
     }
 
-    show({ elevation, loading: false, sources: [...sources] });
+    show({ elevation, loading: false, error, sources: [...sources] });
   },
 };


### PR DESCRIPTION
Offline, a point elevation read left a spinner up for good and reported itself in a danger toast beside it.

`measurementProcessor` added the info toast with `loading: true` and then called `fetchElevations` outside a try/catch of its own, so the rejection escaped to the handler's outer `catch` → `toastError(…, 'elevationFetchError')`. The `measurementInfo` toast was never re-dispatched and kept the spinner it was created with. `objectDetailsProcessor` had the milder version: it caught the failure but reported it as "no data", so the whole elevation line silently vanished.

The readout now carries the error and answers it in place of the value: a red triangle whose `LongPressTooltip` names the reason. `addError` already picks the right wording, so offline it reads "Elevation could not be read: You are not connected to the internet."

- `ElevationValue` — `error` on `ElevationReading`, plus the warning branch
- `ElevationInfo` — forwards it
- `measurementProcessor` — catches the read failure into the toast; an `AbortError` still rethrows, since that means a newer measurement is already re-adding the toast
- `objectDetailsProcessor` — passes the error through rather than dropping the line
- new `fetchError` key in the elevationChart bundle (EN + SK; other locales fall back to English)

Not changed: the measure tool no longer raises a danger toast for *any* failed elevation read, network or otherwise, since the reason is now in the readout. Easy to narrow to `isNetworkError` if that's too broad.

`tsc` and biome clean; 58 tests pass across objects/measurement/elevationChart, including a renamed one asserting the error reaches the toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)