### PR TITLE
fix(elevation-chart): paint categorical colorize as bands, not a gradient

### DIFF
--- a/src/features/elevationChart/chartFill.test.ts
+++ b/src/features/elevationChart/chartFill.test.ts
@@ -1,7 +1,7 @@
 import type { Colorizer, HotlinePalette } from '@shared/colorizers/colorize.js';
 import { NO_DATA_COLOR } from '@shared/colorizers/colorize.js';
 import { describe, expect, it } from 'vitest';
-import { buildFillStops } from './chartFill.js';
+import { buildFillBands, buildFillStops } from './chartFill.js';
 import type { ColorizedAtDistance } from './hooks/useChartColorize.js';
 
 // Black at one end, white at the other, so a palette position reads back as a
@@ -82,24 +82,6 @@ describe('buildFillStops', () => {
     ]);
   });
 
-  it('gives a categorical mode both colours at a boundary, so it meets at an edge', () => {
-    const stops = buildFillStops(
-      categorical,
-      [at(0, 0), at(150, 0), at(150, 1), at(300, 1)],
-      0,
-      300,
-      PLOT,
-    );
-
-    // Black up to the middle, then white from the same offset on.
-    expect(stops).toEqual([
-      { offset: 0, color: 'rgb(0 0 0)' },
-      { offset: 0.5, color: 'rgb(0 0 0)' },
-      { offset: 0.5, color: 'rgb(255 255 255)' },
-      { offset: 1, color: 'rgb(255 255 255)' },
-    ]);
-  });
-
   it('paints a stretch the mode cannot value in the map’s own grey', () => {
     const stops = buildFillStops(
       smooth,
@@ -133,5 +115,69 @@ describe('buildFillStops', () => {
     expect(stops!.at(0)!.offset).toBeLessThanOrEqual(1 / PLOT);
 
     expect(stops!.at(-1)?.offset).toBe(1);
+  });
+});
+
+// A gradient cannot hold a hard edge: a browser rasterizes a wide one through a
+// lookup table of its own size, smearing every step over several pixels. So a
+// mode that names categories is painted as solid bands instead.
+describe('buildFillBands', () => {
+  it('gives each stretch of one value a band, meeting at the boundary', () => {
+    expect(
+      buildFillBands(
+        categorical,
+        [at(0, 0), at(150, 0), at(150, 1), at(300, 1)],
+        0,
+        300,
+      ),
+    ).toEqual([
+      { from: 0, to: 150, color: 'rgb(0 0 0)' },
+      { from: 150, to: 300, color: 'rgb(255 255 255)' },
+    ]);
+  });
+
+  it('keeps a band narrower than a pixel, which is what a gradient washed away', () => {
+    const bands = buildFillBands(
+      categorical,
+      [at(0, 0), at(100, 0), at(100, 1), at(105, 1), at(105, 0), at(300, 0)],
+      0,
+      300,
+    );
+
+    expect(bands).toHaveLength(3);
+
+    expect(bands![1]).toEqual({
+      from: 100,
+      to: 105,
+      color: 'rgb(255 255 255)',
+    });
+  });
+
+  it('clips to what is on screen and drops what is off it', () => {
+    expect(
+      buildFillBands(
+        categorical,
+        [at(0, 0), at(150, 0), at(150, 1), at(300, 1)],
+        200,
+        300,
+      ),
+    ).toEqual([{ from: 200, to: 300, color: 'rgb(255 255 255)' }]);
+  });
+
+  it('bands a stretch the mode cannot value in the map’s own grey', () => {
+    expect(
+      buildFillBands(
+        categorical,
+        [at(0, 0), at(100, 0), at(100, 0, true), at(300, 0, true)],
+        0,
+        300,
+      )?.at(-1),
+    ).toEqual({ from: 100, to: 300, color: NO_DATA_COLOR });
+  });
+
+  it('paints nothing without a colorizer or a second stop', () => {
+    expect(buildFillBands(null, [at(0, 0), at(100, 1)], 0, 100)).toBeNull();
+
+    expect(buildFillBands(categorical, [at(0, 0)], 0, 100)).toBeNull();
   });
 });

--- a/src/features/elevationChart/chartFill.ts
+++ b/src/features/elevationChart/chartFill.ts
@@ -14,16 +14,79 @@ export interface FillStop {
   color: string;
 }
 
+/** A stretch of one colour, in metres along the profile. */
+export interface FillBand {
+  from: number;
+  to: number;
+  color: string;
+}
+
+/**
+ * The fill for a mode that names categories rather than measuring a scale:
+ * one band per stretch of a value, painted solid.
+ *
+ * Not a gradient with a colour change at each boundary, though the stops say
+ * exactly that: a browser rasterizes a wide gradient through a lookup table of
+ * its own size, so every hard step comes out smeared over several pixels — which
+ * on an unzoomed chart, where a stretch is a dozen pixels wide, turns a road
+ * surface into a wash. Solid shapes cannot blend.
+ */
+export function buildFillBands(
+  colorizer: Colorizer | null,
+  stops: ColorizedAtDistance[],
+  vFrom: number,
+  vTo: number,
+): FillBand[] | null {
+  if (!colorizer || stops.length < 2 || !(vTo > vFrom)) {
+    return null;
+  }
+
+  const bands: FillBand[] = [];
+
+  for (const stop of stops) {
+    const color = colorOf(colorizer, stop);
+
+    const last = bands.at(-1);
+
+    if (last?.color === color) {
+      last.to = stop.distance;
+    } else {
+      // A boundary is one distance with a colour on each side, so the next band
+      // starts where the last one ended rather than at its own first stop.
+      bands.push({
+        from: last ? last.to : stop.distance,
+        to: stop.distance,
+        color,
+      });
+    }
+  }
+
+  const visible = bands
+    .map((band) => ({
+      ...band,
+      from: Math.max(band.from, vFrom),
+      to: Math.min(band.to, vTo),
+    }))
+    .filter((band) => band.to > band.from);
+
+  return visible.length ? visible : null;
+}
+
+const colorOf = (colorizer: Colorizer, stop: ColorizedAtDistance) =>
+  stop.gap
+    ? NO_DATA_COLOR
+    : rgbCss(paletteColorAt(colorizer.palette, stop.color));
+
 /**
  * The gradient the profile's fill is painted with, for the stretch of it on
- * screen. `null` where there is nothing to paint.
+ * screen — for the modes that measure a scale; a categorical one is banded
+ * instead (see {@link buildFillBands}). `null` where there is nothing to paint.
  *
- * Three rules earn their keep here: a run of one colour is written as its two
- * ends, not once, or it would blur into whatever follows; a `spanBased` mode
- * gets both colours at a boundary, so categories meet at an edge instead of
- * fading; and at most one stop per pixel column is written, since the list is
- * rebuilt on every frame of a drag and a vertex apiece would be thousands of
- * elements for a gradient the screen shows one colour per pixel of.
+ * Two rules earn their keep here: a run of one colour is written as its two
+ * ends, not once, or it would blur into whatever follows; and at most one stop
+ * per pixel column is written, since the list is rebuilt on every frame of a
+ * drag and a vertex apiece would be thousands of elements for a gradient the
+ * screen shows one colour per pixel of.
  */
 export function buildFillStops(
   colorizer: Colorizer | null,
@@ -74,9 +137,7 @@ export function buildFillStops(
 
     const stop = stops[i]!;
 
-    const color = stop.gap
-      ? NO_DATA_COLOR
-      : rgbCss(paletteColorAt(colorizer.palette, stop.color));
+    const color = colorOf(colorizer, stop);
 
     const offset = clamp((stop.distance - vFrom) / (vTo - vFrom), 0, 1);
 
@@ -94,10 +155,6 @@ export function buildFillStops(
       out.push(pending);
 
       pending = null;
-    }
-
-    if (previous && colorizer.spanBased) {
-      out.push({ offset, color: previous.color });
     }
 
     out.push({ offset, color });

--- a/src/features/elevationChart/components/ElevationChart.tsx
+++ b/src/features/elevationChart/components/ElevationChart.tsx
@@ -36,7 +36,7 @@ import {
 import { Button, CloseButton } from 'react-bootstrap';
 import { FaCog, FaDownload, FaMapMarkerAlt, FaTimes } from 'react-icons/fa';
 import { useDispatch } from 'react-redux';
-import { buildFillStops } from '../chartFill.js';
+import { buildFillBands, buildFillStops } from '../chartFill.js';
 import { useChartColorize } from '../hooks/useChartColorize.js';
 import { useElevationSources } from '../hooks/useElevationSources.js';
 import {
@@ -345,6 +345,8 @@ export default function ElevationChart(): ReactElement | null {
 
   const fillId = `ec-fill-${id}`;
 
+  const areaId = `ec-area-${id}`;
+
   const plotWidth = width - ml - mr;
 
   const d = elevationProfilePoints.at(-1)?.distance ?? NaN;
@@ -387,10 +389,22 @@ export default function ElevationChart(): ReactElement | null {
   // out, plus the pair straddling each edge so the ends are colored too; a
   // categorical mode gets both colors at a boundary rather than a blur across
   // it, and a run of one color is written once.
+  // A mode that names categories is banded; one that measures a scale gets the
+  // gradient. Never both.
+  const banded = colorizer?.spanBased ?? false;
+
   const fillStops = useMemo(
-    () => buildFillStops(colorizer, stops, vFrom, vTo, plotWidth),
-    [colorizer, stops, vFrom, vTo, plotWidth],
+    () =>
+      banded ? null : buildFillStops(colorizer, stops, vFrom, vTo, plotWidth),
+    [banded, colorizer, stops, vFrom, vTo, plotWidth],
   );
+
+  const fillBands = useMemo(
+    () => (banded ? buildFillBands(colorizer, stops, vFrom, vTo) : null),
+    [banded, colorizer, stops, vFrom, vTo],
+  );
+
+  const colorized = Boolean(fillStops || fillBands);
 
   // The whole profile sets the elevation range, zoomed in or not: a scale that
   // followed the window would make two readings of the same chart incomparable,
@@ -924,6 +938,15 @@ export default function ElevationChart(): ReactElement | null {
               {/* User space, not the object's box: the profile is drawn as one
                   polygon per elevated run, and each would otherwise stretch the
                   whole gradient across its own width. */}
+              {/* The drawn area itself, so the bands can be kept inside it. */}
+              {fillBands && (
+                <clipPath id={areaId}>
+                  {paths.map(({ area }, i) => (
+                    <polygon key={i} points={area} />
+                  ))}
+                </clipPath>
+              )}
+
               {fillStops && (
                 <linearGradient
                   id={fillId}
@@ -953,28 +976,55 @@ export default function ElevationChart(): ReactElement | null {
             of points with elevation. A missing value breaks the line and its
             fill rather than dropping to the baseline. */}
             <g className="chart" clipPath={`url(#${clipId})`}>
-              {paths.map(({ line, area }, i) => (
-                <g className="chart-segment" key={`seg${i}`}>
-                  <polygon
-                    points={area}
-                    fill={
-                      fillStops
-                        ? `url(#${fillId})`
-                        : 'var(--bs-primary-bg-subtle)'
-                    }
-                  />
+              {paths.map(({ area }, i) => (
+                <polygon
+                  key={`area${i}`}
+                  className="chart-area"
+                  points={area}
+                  fill={
+                    fillStops
+                      ? `url(#${fillId})`
+                      : 'var(--bs-primary-bg-subtle)'
+                  }
+                />
+              ))}
 
-                  {/* The colorized fill is what carries the reading, so the
-                      outline steps back to a neutral edge for it. */}
-                  <polyline
-                    points={line}
-                    stroke={
-                      fillStops ? 'var(--bs-body-color)' : 'var(--bs-primary)'
-                    }
-                    strokeWidth={1}
-                    fill="none"
-                  />
+              {/* Categories painted as solid bands, kept inside the area by the
+                  same polygons. */}
+              {fillBands && (
+                <g className="chart-bands" clipPath={`url(#${areaId})`}>
+                  {fillBands.map(({ from, to, color }, i) => (
+                    <rect
+                      key={`band${i}`}
+                      x={mapX(from)}
+                      y={mt}
+                      // A pixel wider than the band, so the next one paints over
+                      // the overhang: two anti-aliased edges meeting on a
+                      // fractional coordinate each cover half of it, and the
+                      // ground shows through the seam. The boundary stays where
+                      // it was — it is the next band's own left edge. The last
+                      // band's overhang is taken off by the area clip.
+                      width={mapX(to) - mapX(from) + 1}
+                      height={height - mt - mb}
+                      fill={color}
+                    />
+                  ))}
                 </g>
+              )}
+
+              {/* The colorized fill is what carries the reading, so the outline
+                  steps back to a neutral edge for it. */}
+              {paths.map(({ line }, i) => (
+                <polyline
+                  key={`line${i}`}
+                  className="chart-line"
+                  points={line}
+                  stroke={
+                    colorized ? 'var(--bs-body-color)' : 'var(--bs-primary)'
+                  }
+                  strokeWidth={1}
+                  fill="none"
+                />
               ))}
             </g>
 


### PR DESCRIPTION
Unzoomed, a surface-colorized profile came out as a wash rather than distinct stretches. Zooming in fixed it; panning at minimum zoom made the areas flicker between sharp and smeared.

### It isn't our SVG

The gradient carries a **coincident stop pair** at every boundary — two stops at one offset, which is a hard edge per spec. Read straight off the live chart: 132 stops, 44 pairs, `gradientUnits="userSpaceOnUse"`. Rasterising it and reading pixels showed a brown→green boundary taking **6 px** inside a band only 7 px wide.

Chrome resolves a linear gradient through a lookup table of a fixed 256 entries across the gradient's own length. On a 1769 px plot that is ~6.9 px per entry, so any colour step narrower than that cannot be represented and is blended with its neighbours. Measured with a standalone page ([repro gist](https://gist.github.com/zdila/17792648f45fa60c809a6bb99e11d9e2)) in Chrome 151:

| bands across 1600 px | width each | widest blend |
| --- | --- | --- |
| 2 | 800 px | 1 px ✓ |
| 16 | 100 px | 1 px ✓ |
| 80 | 20 px | **7 px** |
| 160 | 10 px | **14 px** |
| 256 | 6.3 px | **1594 px** — the whole gradient |

Firefox renders every case exactly. That also explains both symptoms: unzoomed, a surface stretch on a 35 km route is ~10 px wide, so most of each band is transition; and panning shifts every band by a sub-pixel amount, which flips bands across the threshold as you drag.

### The fix

A mode that *names categories* no longer goes through a gradient at all. It paints one solid `<rect>` per stretch, clipped to the profile's own area polygons. Solid shapes cannot blend, at any zoom or density. Modes that *measure a scale* (elevation, steepness, speed, …) keep the gradient, where interpolation is the point.

Two details worth knowing:

- Each band is drawn a pixel wider than it is, and the next one paints over the overhang. Two anti-aliased edges meeting on a fractional coordinate each cover half of it, and the ground shows through the seam; the boundary still lands exactly where it did, because it is the next band's own left edge, and the last band's overhang is taken off by the area clip.
- Bands also rescue a stretch narrower than a pixel, which the gradient washed away entirely — covered by a test.

### Tests

Five cases for `buildFillBands` (tiling at a boundary, a sub-pixel band, clipping to the visible window, the no-data grey, and the empty cases). `buildFillStops` keeps its own and loses the `spanBased` hard-edge branch it no longer needs.

### Upstream

Reported to Chromium: https://issues.chromium.org/issues/554940581 — with a self-measuring repro at https://gistpreview.github.io/?17792648f45fa60c809a6bb99e11d9e2, which rasterises each gradient and prints the widest blend, so the numbers above can be reproduced on any machine. Firefox renders every case exactly.

Skia's 256-entry gradient table is a long-known limitation, but the reports I could find are about banding in *smooth* gradients rather than hard stops being erased. This branch does not depend on any of that being fixed — solid rects never enter the gradient path.

